### PR TITLE
实现对composite model(聚合模型)和对webm、gif等视频动态立绘的支持

### DIFF
--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -30,7 +30,7 @@ msgstr "<0>Apply a new template</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>Current template: {currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:304
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,19 +94,19 @@ msgstr "Intro texts"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "JSONL 动作"
 msgstr ""
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:339
 msgid "JSONL 表情"
 msgstr ""
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "Live2D 动作"
 msgstr "Live2D Motion"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:339
 msgid "Live2D 表情"
 msgstr "Live2D Expression"
 
@@ -150,7 +150,7 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "Spine 动画"
 msgstr "Spine animation"
 
@@ -200,7 +200,7 @@ msgstr "Y"
 msgid "Y轴缩放"
 msgstr "Scale y"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:295
 msgid "z-index"
 msgstr "z-index"
 
@@ -254,7 +254,7 @@ msgstr " Words"
 msgid "中"
 msgstr "Medium"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:61
 msgid "中间"
 msgstr "Center"
 
@@ -344,7 +344,7 @@ msgstr "Use prepared apply target, if target set the ID, it won't apply"
 msgid "使用预设目标"
 msgstr "Use prepared target"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:331
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:360
 msgid "例如：-100,-100,100,100"
 msgstr "For example: -100,-100,100,100 "
 
@@ -453,8 +453,8 @@ msgstr "Hide the avatar"
 msgid "关闭效果音"
 msgstr "Stop the sound effect"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:232
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:241
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:257
 msgid "关闭立绘"
 msgstr "Hide the figure"
 
@@ -601,7 +601,7 @@ msgstr "Bold"
 msgid "动画"
 msgstr "Animation"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:430
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:459
 msgid "半张嘴"
 msgstr "Half open mouth"
 
@@ -649,7 +649,7 @@ msgstr "Transform"
 msgid "可选项"
 msgstr "Selectable options"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:58
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
 msgid "右侧"
 msgstr "Right"
 
@@ -685,7 +685,7 @@ msgstr "Enabled"
 msgid "启用视频跳过"
 msgstr "Enable video skipping"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:402
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:431
 msgid "唇形同步与眨眼"
 msgstr "Lip sync and blinking"
 
@@ -925,7 +925,7 @@ msgstr "Show avatar"
 msgid "属性"
 msgstr "Property"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:62
 msgid "左侧"
 msgstr "Left"
 
@@ -991,7 +991,7 @@ msgstr "Delay time (seconds)"
 msgid "开启"
 msgstr "On"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:413
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:442
 msgid "张开嘴"
 msgstr "Open mouth"
 
@@ -1003,6 +1003,14 @@ msgstr "Intensity"
 #: src/pages/dashboard/DashBoard.tsx:156
 msgid "当前版本"
 msgstr "Current version"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:71
+msgid "循环播放"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+msgid "循环模式（仅视频/GIF 立绘）"
+msgstr ""
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:240
 msgid "德语"
@@ -1027,7 +1035,7 @@ msgid "手动输入 ID"
 msgstr "Manually enter ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:108
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:380
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:409
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
 msgid "打开效果编辑器"
 msgstr "Open effect editor"
@@ -1102,7 +1110,7 @@ msgstr "Tip: After editing, if you find any invalid CG/BGM in the appreciation g
 msgid "提示：换行符最多可达三行"
 msgstr "Tip: Line breaks can be up to three lines"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:500
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:529
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "Tip: The effect will only take place when switching to a different character sprite or closing the current sprite and adding it again. If you want to set an effect for an existing sprite, please use a separate command for setting effects."
 
@@ -1121,6 +1129,14 @@ msgstr ""
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:120
 msgid "播放一小段视频"
 msgstr "Play a short video"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
+msgid "播放一次后消失"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
+msgid "播放一次并停在最后一帧"
+msgstr ""
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:184
 msgid "播放一段效果音"
@@ -1155,7 +1171,7 @@ msgid "效果编辑"
 msgstr "Effect editing"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:112
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:385
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:414
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:64
 msgid "效果编辑器"
 msgstr "Effect editor"
@@ -1359,7 +1375,7 @@ msgid "显示侧边栏"
 msgstr "Show sidebar"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:105
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:374
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:403
 msgid "显示效果"
 msgstr "Display effect"
 
@@ -1367,7 +1383,7 @@ msgstr "Display effect"
 msgid "显示文本框"
 msgstr "Show text box"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:258
 msgid "显示立绘"
 msgstr "Show figure"
 
@@ -1400,14 +1416,14 @@ msgid "本句前插入句子"
 msgstr "Insert sentence before this"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:273
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:289
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后执行下一句"
 msgstr "Execute next sentence after this"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:274
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:290
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后等待"
@@ -1649,7 +1665,7 @@ msgstr "No file currently open"
 msgid "相对"
 msgstr "Relative"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:464
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:493
 msgid "睁开眼睛"
 msgstr "Open eyes"
 
@@ -1698,7 +1714,7 @@ msgstr "Disabled"
 msgid "立绘"
 msgstr "Figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:387
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:113
@@ -1706,11 +1722,11 @@ msgstr "Figure"
 msgid "立绘 ID"
 msgstr "Figure ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:378
 msgid "立绘ID（可选）"
 msgstr "Figure ID (optional)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:367
 msgid "立绘位置"
 msgstr "Figure position"
 
@@ -1718,7 +1734,7 @@ msgstr "Figure position"
 msgid "立绘插图的ID"
 msgstr "ID of figure illustration"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:264
 msgid "立绘文件"
 msgstr "Figure file"
 
@@ -1729,10 +1745,6 @@ msgstr "Simplified Chinese"
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:209
 msgid "紧急回避"
 msgstr "Emergency Evasion"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
-msgid "繁体中文"
-msgstr "Traditional Chinese"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1810,7 +1822,7 @@ msgid "缓出"
 msgstr "Ease out"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:363
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:392
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:117
 msgid "缓动类型"
 msgstr "Ease type"
@@ -1830,6 +1842,10 @@ msgstr "Edit game"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "Edit component"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+msgid "繁体中文"
+msgstr "Traditional Chinese"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
@@ -1906,7 +1922,7 @@ msgstr "Auto-hide toolbar"
 msgid "自定义"
 msgstr "Customization"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:351
 msgid "自定义 Live2D 绘制范围"
 msgstr "Custom Live2D drawing area"
 
@@ -1927,7 +1943,7 @@ msgstr "Custom effect name"
 msgid "自定义级联选择器分隔符"
 msgstr ""
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:351
 msgid "自定义绘制范围"
 msgstr ""
 
@@ -2144,8 +2160,8 @@ msgstr "Enter Target ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:114
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:388
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:391
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:420
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:71
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:74
 msgid "过渡时间（单位为毫秒）"
@@ -2172,7 +2188,7 @@ msgid "进出场动画"
 msgstr "Entry and exit animation"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:266
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:282
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
 msgid "连续执行"
@@ -2234,13 +2250,13 @@ msgstr "Select game engine version"
 msgid "选择视频文件"
 msgstr "Choose video file"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:237
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:434
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:451
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:468
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:485
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:253
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:268
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:446
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:463
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:480
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:497
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:514
 msgid "选择立绘文件"
 msgstr "Choose Figure File"
 
@@ -2368,11 +2384,11 @@ msgstr "Appreciation Asset File"
 msgid "鉴赏音乐"
 msgstr "Appreciation Music"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:447
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:476
 msgid "闭上嘴"
 msgstr "Close Mouth"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:481
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:510
 msgid "闭上眼睛"
 msgstr "Close Eyes"
 

--- a/packages/origine2/src/locales/en.po
+++ b/packages/origine2/src/locales/en.po
@@ -30,7 +30,7 @@ msgstr "<0>Apply a new template</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>Current template: {currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:216
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,11 +94,19 @@ msgstr "Intro texts"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:222
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+msgid "JSONL 动作"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+msgid "JSONL 表情"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
 msgid "Live2D 动作"
 msgstr "Live2D Motion"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:233
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
 msgid "Live2D 表情"
 msgstr "Live2D Expression"
 
@@ -142,7 +150,7 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:222
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
 msgid "Spine 动画"
 msgstr "Spine animation"
 
@@ -192,7 +200,7 @@ msgstr "Y"
 msgid "Y轴缩放"
 msgstr "Scale y"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:208
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
 msgid "z-index"
 msgstr "z-index"
 
@@ -246,7 +254,7 @@ msgstr " Words"
 msgid "中"
 msgstr "Medium"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:55
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
 msgid "中间"
 msgstr "Center"
 
@@ -336,7 +344,7 @@ msgstr "Use prepared apply target, if target set the ID, it won't apply"
 msgid "使用预设目标"
 msgstr "Use prepared target"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:331
 msgid "例如：-100,-100,100,100"
 msgstr "For example: -100,-100,100,100 "
 
@@ -445,8 +453,8 @@ msgstr "Hide the avatar"
 msgid "关闭效果音"
 msgstr "Stop the sound effect"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:181
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:188
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:232
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:241
 msgid "关闭立绘"
 msgstr "Hide the figure"
 
@@ -593,7 +601,7 @@ msgstr "Bold"
 msgid "动画"
 msgstr "Animation"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:334
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:430
 msgid "半张嘴"
 msgstr "Half open mouth"
 
@@ -641,7 +649,7 @@ msgstr "Transform"
 msgid "可选项"
 msgstr "Selectable options"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:58
 msgid "右侧"
 msgstr "Right"
 
@@ -677,7 +685,7 @@ msgstr "Enabled"
 msgid "启用视频跳过"
 msgstr "Enable video skipping"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:311
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:402
 msgid "唇形同步与眨眼"
 msgstr "Lip sync and blinking"
 
@@ -917,7 +925,7 @@ msgstr "Show avatar"
 msgid "属性"
 msgstr "Property"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
 msgid "左侧"
 msgstr "Left"
 
@@ -983,7 +991,7 @@ msgstr "Delay time (seconds)"
 msgid "开启"
 msgstr "On"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:413
 msgid "张开嘴"
 msgstr "Open mouth"
 
@@ -1019,7 +1027,7 @@ msgid "手动输入 ID"
 msgstr "Manually enter ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:108
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:294
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:380
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
 msgid "打开效果编辑器"
 msgstr "Open effect editor"
@@ -1094,7 +1102,7 @@ msgstr "Tip: After editing, if you find any invalid CG/BGM in the appreciation g
 msgid "提示：换行符最多可达三行"
 msgstr "Tip: Line breaks can be up to three lines"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:384
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:500
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "Tip: The effect will only take place when switching to a different character sprite or closing the current sprite and adding it again. If you want to set an effect for an existing sprite, please use a separate command for setting effects."
 
@@ -1147,7 +1155,7 @@ msgid "效果编辑"
 msgstr "Effect editing"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:112
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:385
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:64
 msgid "效果编辑器"
 msgstr "Effect editor"
@@ -1351,7 +1359,7 @@ msgid "显示侧边栏"
 msgstr "Show sidebar"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:105
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:291
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:374
 msgid "显示效果"
 msgstr "Display effect"
 
@@ -1359,7 +1367,7 @@ msgstr "Display effect"
 msgid "显示文本框"
 msgstr "Show text box"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:188
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "显示立绘"
 msgstr "Show figure"
 
@@ -1392,14 +1400,14 @@ msgid "本句前插入句子"
 msgstr "Insert sentence before this"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:205
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:273
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后执行下一句"
 msgstr "Execute next sentence after this"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后等待"
@@ -1641,7 +1649,7 @@ msgstr "No file currently open"
 msgid "相对"
 msgstr "Relative"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:464
 msgid "睁开眼睛"
 msgstr "Open eyes"
 
@@ -1690,7 +1698,7 @@ msgstr "Disabled"
 msgid "立绘"
 msgstr "Figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:277
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:113
@@ -1698,11 +1706,11 @@ msgstr "Figure"
 msgid "立绘 ID"
 msgstr "Figure ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:269
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
 msgid "立绘ID（可选）"
 msgstr "Figure ID (optional)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
 msgid "立绘位置"
 msgstr "Figure position"
 
@@ -1710,7 +1718,7 @@ msgstr "Figure position"
 msgid "立绘插图的ID"
 msgstr "ID of figure illustration"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:191
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
 msgid "立绘文件"
 msgstr "Figure file"
 
@@ -1721,6 +1729,10 @@ msgstr "Simplified Chinese"
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:209
 msgid "紧急回避"
 msgstr "Emergency Evasion"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+msgid "繁体中文"
+msgstr "Traditional Chinese"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1798,7 +1810,7 @@ msgid "缓出"
 msgstr "Ease out"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:281
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:363
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:117
 msgid "缓动类型"
 msgstr "Ease type"
@@ -1818,10 +1830,6 @@ msgstr "Edit game"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "Edit component"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
-msgid "繁体中文"
-msgstr "Traditional Chinese"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
@@ -1898,7 +1906,7 @@ msgstr "Auto-hide toolbar"
 msgid "自定义"
 msgstr "Customization"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:244
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
 msgid "自定义 Live2D 绘制范围"
 msgstr "Custom Live2D drawing area"
 
@@ -1917,6 +1925,10 @@ msgstr "Custom effect name"
 
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:146
 msgid "自定义级联选择器分隔符"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+msgid "自定义绘制范围"
 msgstr ""
 
 #: src/pages/editor/Topbar/tabs/AddSentence/AddSentenceTab.tsx:45
@@ -2132,8 +2144,8 @@ msgstr "Enter Target ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:114
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:300
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:302
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:388
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:391
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:71
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:74
 msgid "过渡时间（单位为毫秒）"
@@ -2160,7 +2172,7 @@ msgid "进出场动画"
 msgstr "Entry and exit animation"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:201
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:266
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
 msgid "连续执行"
@@ -2222,13 +2234,13 @@ msgstr "Select game engine version"
 msgid "选择视频文件"
 msgstr "Choose video file"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:184
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:194
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:325
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:337
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:361
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:373
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:237
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:434
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:451
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:468
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:485
 msgid "选择立绘文件"
 msgstr "Choose Figure File"
 
@@ -2356,11 +2368,11 @@ msgstr "Appreciation Asset File"
 msgid "鉴赏音乐"
 msgstr "Appreciation Music"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:346
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:447
 msgid "闭上嘴"
 msgstr "Close Mouth"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:370
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:481
 msgid "闭上眼睛"
 msgstr "Close Eyes"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -30,7 +30,7 @@ msgstr "<0>新しいテンプレートを適用する</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>現在適用中のテンプレート：{currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:304
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,19 +94,19 @@ msgstr "Intro テキスト"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "JSONL 动作"
 msgstr ""
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:339
 msgid "JSONL 表情"
 msgstr ""
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "Live2D 动作"
 msgstr "Live2D モーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:339
 msgid "Live2D 表情"
 msgstr "Live2D 表情"
 
@@ -150,7 +150,7 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "Spine 动画"
 msgstr "Spine アニメーション"
 
@@ -203,7 +203,7 @@ msgstr "Y軸位移"
 msgid "Y轴缩放"
 msgstr "Y軸スケール"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:295
 msgid "z-index"
 msgstr "z-index"
 
@@ -257,7 +257,7 @@ msgstr " ワード"
 msgid "中"
 msgstr "中央"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:61
 msgid "中间"
 msgstr "中央"
 
@@ -347,7 +347,7 @@ msgstr "以前に設定されたアクションターゲットを使用。IDを�
 msgid "使用预设目标"
 msgstr "事前設定されたターゲットを使用"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:331
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:360
 msgid "例如：-100,-100,100,100"
 msgstr "例えば：-100,-100,100,100"
 
@@ -456,8 +456,8 @@ msgstr "アバターを非表示"
 msgid "关闭效果音"
 msgstr "効果音を停止"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:232
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:241
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:257
 msgid "关闭立绘"
 msgstr "立ち絵を非表示"
 
@@ -604,7 +604,7 @@ msgstr "太字"
 msgid "动画"
 msgstr "アニメーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:430
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:459
 msgid "半张嘴"
 msgstr "半分開いた口"
 
@@ -652,7 +652,7 @@ msgstr "トランスフォーム"
 msgid "可选项"
 msgstr "選択可能な選択肢"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:58
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
 msgid "右侧"
 msgstr "右"
 
@@ -688,7 +688,7 @@ msgstr "有効化"
 msgid "启用视频跳过"
 msgstr "動画のスキップを有効にする"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:402
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:431
 msgid "唇形同步与眨眼"
 msgstr "口パクとまばたき"
 
@@ -928,7 +928,7 @@ msgstr "アバターを表示"
 msgid "属性"
 msgstr "プロパティ"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:62
 msgid "左侧"
 msgstr "左"
 
@@ -994,7 +994,7 @@ msgstr "遅延時間（秒）"
 msgid "开启"
 msgstr "有効化"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:413
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:442
 msgid "张开嘴"
 msgstr "開いた口"
 
@@ -1006,6 +1006,14 @@ msgstr "強度"
 #: src/pages/dashboard/DashBoard.tsx:156
 msgid "当前版本"
 msgstr "現在のバージョン"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:71
+msgid "循环播放"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+msgid "循环模式（仅视频/GIF 立绘）"
+msgstr ""
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:240
 msgid "德语"
@@ -1030,7 +1038,7 @@ msgid "手动输入 ID"
 msgstr "IDを手動で設定"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:108
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:380
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:409
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
 msgid "打开效果编辑器"
 msgstr "エフェクトエディタを開く"
@@ -1105,7 +1113,7 @@ msgstr "ヒント: 編集後に無効なCG/BGMが見つかった場合は、WebG
 msgid "提示：换行符最多可达三行"
 msgstr "ヒント:改行は三行まで可能"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:500
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:529
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "ヒント：この効果は、異なる立ち絵に切り替えるか、一度立ち絵を閉じてから再度追加した場合にのみ有効です。既存の立ち絵に効果を設定する場合は、個別の効果設定コマンドを使用してください。"
 
@@ -1124,6 +1132,14 @@ msgstr ""
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:120
 msgid "播放一小段视频"
 msgstr "動画ファイルを再生する"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
+msgid "播放一次后消失"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
+msgid "播放一次并停在最后一帧"
+msgstr ""
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:184
 msgid "播放一段效果音"
@@ -1158,7 +1174,7 @@ msgid "效果编辑"
 msgstr "エフェクトエディタ"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:112
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:385
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:414
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:64
 msgid "效果编辑器"
 msgstr "エフェクトエディタ"
@@ -1358,7 +1374,7 @@ msgid "显示侧边栏"
 msgstr "サイドバーを表示"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:105
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:374
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:403
 msgid "显示效果"
 msgstr "エフェクト"
 
@@ -1366,7 +1382,7 @@ msgstr "エフェクト"
 msgid "显示文本框"
 msgstr "テキストボックスを表示"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:258
 msgid "显示立绘"
 msgstr "立ち絵を表示"
 
@@ -1399,14 +1415,14 @@ msgid "本句前插入句子"
 msgstr "選択した文の前に追加"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:273
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:289
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后执行下一句"
 msgstr "この文が実行された後、次の文を実行"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:274
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:290
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后等待"
@@ -1648,7 +1664,7 @@ msgstr "現在開いているファイルはありません"
 msgid "相对"
 msgstr "相対"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:464
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:493
 msgid "睁开眼睛"
 msgstr "開いた目"
 
@@ -1697,7 +1713,7 @@ msgstr "無効化"
 msgid "立绘"
 msgstr "Figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:387
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:113
@@ -1705,11 +1721,11 @@ msgstr "Figure"
 msgid "立绘 ID"
 msgstr "立ち絵ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:378
 msgid "立绘ID（可选）"
 msgstr "立ち絵ID(オプション)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:367
 msgid "立绘位置"
 msgstr "描画位置"
 
@@ -1717,7 +1733,7 @@ msgstr "描画位置"
 msgid "立绘插图的ID"
 msgstr "関連する立ち絵のID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:264
 msgid "立绘文件"
 msgstr "立ち絵ファイル"
 
@@ -1728,10 +1744,6 @@ msgstr "簡体字中国語"
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:209
 msgid "紧急回避"
 msgstr "緊急回避"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
-msgid "繁体中文"
-msgstr "繁体字中国語"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1809,7 +1821,7 @@ msgid "缓出"
 msgstr "イーズアウト"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:363
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:392
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:117
 msgid "缓动类型"
 msgstr "イージングタイプ"
@@ -1829,6 +1841,10 @@ msgstr "ゲームの編集"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "コンポーネントの編集"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+msgid "繁体中文"
+msgstr "繁体字中国語"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
@@ -1905,7 +1921,7 @@ msgstr "ツールバーを自動的に隠す"
 msgid "自定义"
 msgstr "カスタム"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:351
 msgid "自定义 Live2D 绘制范围"
 msgstr "Live2D 描画範囲のカスタマイズ"
 
@@ -1926,7 +1942,7 @@ msgstr "カスタムの特殊効果名"
 msgid "自定义级联选择器分隔符"
 msgstr ""
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:351
 msgid "自定义绘制范围"
 msgstr ""
 
@@ -2143,8 +2159,8 @@ msgstr "ターゲットIDを入力"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:114
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:388
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:391
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:420
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:71
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:74
 msgid "过渡时间（单位为毫秒）"
@@ -2171,7 +2187,7 @@ msgid "进出场动画"
 msgstr "入退場アニメーション"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:266
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:282
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
 msgid "连续执行"
@@ -2233,13 +2249,13 @@ msgstr "ゲームエンジンのバージョンを選択"
 msgid "选择视频文件"
 msgstr "動画ファイルを選択"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:237
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:434
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:451
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:468
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:485
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:253
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:268
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:446
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:463
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:480
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:497
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:514
 msgid "选择立绘文件"
 msgstr "立ち絵ファイルを選択"
 
@@ -2367,11 +2383,11 @@ msgstr "CG/BGMファイルを選択"
 msgid "鉴赏音乐"
 msgstr "BGM鑑賞"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:447
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:476
 msgid "闭上嘴"
 msgstr "閉じた口"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:481
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:510
 msgid "闭上眼睛"
 msgstr "閉じた目"
 

--- a/packages/origine2/src/locales/ja.po
+++ b/packages/origine2/src/locales/ja.po
@@ -30,7 +30,7 @@ msgstr "<0>新しいテンプレートを適用する</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>現在適用中のテンプレート：{currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:216
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,11 +94,19 @@ msgstr "Intro テキスト"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:222
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+msgid "JSONL 动作"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+msgid "JSONL 表情"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
 msgid "Live2D 动作"
 msgstr "Live2D モーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:233
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
 msgid "Live2D 表情"
 msgstr "Live2D 表情"
 
@@ -142,7 +150,7 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:222
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
 msgid "Spine 动画"
 msgstr "Spine アニメーション"
 
@@ -195,7 +203,7 @@ msgstr "Y軸位移"
 msgid "Y轴缩放"
 msgstr "Y軸スケール"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:208
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
 msgid "z-index"
 msgstr "z-index"
 
@@ -249,7 +257,7 @@ msgstr " ワード"
 msgid "中"
 msgstr "中央"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:55
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
 msgid "中间"
 msgstr "中央"
 
@@ -339,7 +347,7 @@ msgstr "以前に設定されたアクションターゲットを使用。IDを�
 msgid "使用预设目标"
 msgstr "事前設定されたターゲットを使用"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:331
 msgid "例如：-100,-100,100,100"
 msgstr "例えば：-100,-100,100,100"
 
@@ -448,8 +456,8 @@ msgstr "アバターを非表示"
 msgid "关闭效果音"
 msgstr "効果音を停止"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:181
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:188
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:232
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:241
 msgid "关闭立绘"
 msgstr "立ち絵を非表示"
 
@@ -596,7 +604,7 @@ msgstr "太字"
 msgid "动画"
 msgstr "アニメーション"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:334
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:430
 msgid "半张嘴"
 msgstr "半分開いた口"
 
@@ -644,7 +652,7 @@ msgstr "トランスフォーム"
 msgid "可选项"
 msgstr "選択可能な選択肢"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:58
 msgid "右侧"
 msgstr "右"
 
@@ -680,7 +688,7 @@ msgstr "有効化"
 msgid "启用视频跳过"
 msgstr "動画のスキップを有効にする"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:311
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:402
 msgid "唇形同步与眨眼"
 msgstr "口パクとまばたき"
 
@@ -920,7 +928,7 @@ msgstr "アバターを表示"
 msgid "属性"
 msgstr "プロパティ"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
 msgid "左侧"
 msgstr "左"
 
@@ -986,7 +994,7 @@ msgstr "遅延時間（秒）"
 msgid "开启"
 msgstr "有効化"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:413
 msgid "张开嘴"
 msgstr "開いた口"
 
@@ -1022,7 +1030,7 @@ msgid "手动输入 ID"
 msgstr "IDを手動で設定"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:108
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:294
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:380
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
 msgid "打开效果编辑器"
 msgstr "エフェクトエディタを開く"
@@ -1097,7 +1105,7 @@ msgstr "ヒント: 編集後に無効なCG/BGMが見つかった場合は、WebG
 msgid "提示：换行符最多可达三行"
 msgstr "ヒント:改行は三行まで可能"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:384
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:500
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "ヒント：この効果は、異なる立ち絵に切り替えるか、一度立ち絵を閉じてから再度追加した場合にのみ有効です。既存の立ち絵に効果を設定する場合は、個別の効果設定コマンドを使用してください。"
 
@@ -1150,7 +1158,7 @@ msgid "效果编辑"
 msgstr "エフェクトエディタ"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:112
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:385
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:64
 msgid "效果编辑器"
 msgstr "エフェクトエディタ"
@@ -1350,7 +1358,7 @@ msgid "显示侧边栏"
 msgstr "サイドバーを表示"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:105
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:291
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:374
 msgid "显示效果"
 msgstr "エフェクト"
 
@@ -1358,7 +1366,7 @@ msgstr "エフェクト"
 msgid "显示文本框"
 msgstr "テキストボックスを表示"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:188
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "显示立绘"
 msgstr "立ち絵を表示"
 
@@ -1391,14 +1399,14 @@ msgid "本句前插入句子"
 msgstr "選択した文の前に追加"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:205
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:273
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后执行下一句"
 msgstr "この文が実行された後、次の文を実行"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后等待"
@@ -1640,7 +1648,7 @@ msgstr "現在開いているファイルはありません"
 msgid "相对"
 msgstr "相対"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:464
 msgid "睁开眼睛"
 msgstr "開いた目"
 
@@ -1689,7 +1697,7 @@ msgstr "無効化"
 msgid "立绘"
 msgstr "Figure"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:277
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:113
@@ -1697,11 +1705,11 @@ msgstr "Figure"
 msgid "立绘 ID"
 msgstr "立ち絵ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:269
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
 msgid "立绘ID（可选）"
 msgstr "立ち絵ID(オプション)"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
 msgid "立绘位置"
 msgstr "描画位置"
 
@@ -1709,7 +1717,7 @@ msgstr "描画位置"
 msgid "立绘插图的ID"
 msgstr "関連する立ち絵のID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:191
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
 msgid "立绘文件"
 msgstr "立ち絵ファイル"
 
@@ -1720,6 +1728,10 @@ msgstr "簡体字中国語"
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:209
 msgid "紧急回避"
 msgstr "緊急回避"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+msgid "繁体中文"
+msgstr "繁体字中国語"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1797,7 +1809,7 @@ msgid "缓出"
 msgstr "イーズアウト"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:281
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:363
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:117
 msgid "缓动类型"
 msgstr "イージングタイプ"
@@ -1817,10 +1829,6 @@ msgstr "ゲームの編集"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "コンポーネントの編集"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
-msgid "繁体中文"
-msgstr "繁体字中国語"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
@@ -1897,7 +1905,7 @@ msgstr "ツールバーを自動的に隠す"
 msgid "自定义"
 msgstr "カスタム"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:244
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
 msgid "自定义 Live2D 绘制范围"
 msgstr "Live2D 描画範囲のカスタマイズ"
 
@@ -1916,6 +1924,10 @@ msgstr "カスタムの特殊効果名"
 
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:146
 msgid "自定义级联选择器分隔符"
+msgstr ""
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+msgid "自定义绘制范围"
 msgstr ""
 
 #: src/pages/editor/Topbar/tabs/AddSentence/AddSentenceTab.tsx:45
@@ -2131,8 +2143,8 @@ msgstr "ターゲットIDを入力"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:114
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:300
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:302
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:388
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:391
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:71
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:74
 msgid "过渡时间（单位为毫秒）"
@@ -2159,7 +2171,7 @@ msgid "进出场动画"
 msgstr "入退場アニメーション"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:201
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:266
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
 msgid "连续执行"
@@ -2221,13 +2233,13 @@ msgstr "ゲームエンジンのバージョンを選択"
 msgid "选择视频文件"
 msgstr "動画ファイルを選択"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:184
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:194
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:325
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:337
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:361
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:373
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:237
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:434
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:451
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:468
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:485
 msgid "选择立绘文件"
 msgstr "立ち絵ファイルを選択"
 
@@ -2355,11 +2367,11 @@ msgstr "CG/BGMファイルを選択"
 msgid "鉴赏音乐"
 msgstr "BGM鑑賞"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:346
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:447
 msgid "闭上嘴"
 msgstr "閉じた口"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:370
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:481
 msgid "闭上眼睛"
 msgstr "閉じた目"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -30,7 +30,7 @@ msgstr "<0>应用新的模板</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>当前应用的模板：{currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:304
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,19 +94,19 @@ msgstr "Intro 文本"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "JSONL 动作"
 msgstr "JSONL 动作"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:339
 msgid "JSONL 表情"
 msgstr "JSONL 表情"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "Live2D 动作"
 msgstr "Live2D 动作"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:339
 msgid "Live2D 表情"
 msgstr "Live2D 表情"
 
@@ -150,7 +150,7 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:326
 msgid "Spine 动画"
 msgstr "Spine 动画"
 
@@ -202,7 +202,7 @@ msgstr "Y轴位移"
 msgid "Y轴缩放"
 msgstr "Y轴缩放"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:295
 msgid "z-index"
 msgstr "z-index"
 
@@ -256,7 +256,7 @@ msgstr "个字"
 msgid "中"
 msgstr "中"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:61
 msgid "中间"
 msgstr "中间"
 
@@ -346,7 +346,7 @@ msgstr "使用预设的作用目标，如果设置了id则不生效"
 msgid "使用预设目标"
 msgstr "使用预设目标"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:331
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:360
 msgid "例如：-100,-100,100,100"
 msgstr "例如：-100,-100,100,100"
 
@@ -455,8 +455,8 @@ msgstr "关闭小头像"
 msgid "关闭效果音"
 msgstr "关闭效果音"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:232
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:241
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:257
 msgid "关闭立绘"
 msgstr "关闭立绘"
 
@@ -603,7 +603,7 @@ msgstr "加粗"
 msgid "动画"
 msgstr "动画"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:430
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:459
 msgid "半张嘴"
 msgstr "半张嘴"
 
@@ -651,7 +651,7 @@ msgstr "变换"
 msgid "可选项"
 msgstr "可选项"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:58
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:63
 msgid "右侧"
 msgstr "右侧"
 
@@ -687,7 +687,7 @@ msgstr "启用"
 msgid "启用视频跳过"
 msgstr "启用视频跳过"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:402
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:431
 msgid "唇形同步与眨眼"
 msgstr "唇形同步与眨眼"
 
@@ -927,7 +927,7 @@ msgstr "展示小头像"
 msgid "属性"
 msgstr "属性"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:62
 msgid "左侧"
 msgstr "左侧"
 
@@ -993,7 +993,7 @@ msgstr "延迟时间（秒）"
 msgid "开启"
 msgstr "开启"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:413
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:442
 msgid "张开嘴"
 msgstr "张开嘴"
 
@@ -1005,6 +1005,14 @@ msgstr "强度"
 #: src/pages/dashboard/DashBoard.tsx:156
 msgid "当前版本"
 msgstr "当前版本"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:71
+msgid "循环播放"
+msgstr "循环播放"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+msgid "循环模式（仅视频/GIF 立绘）"
+msgstr "循环模式（仅视频/GIF 立绘）"
 
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:240
 msgid "德语"
@@ -1029,7 +1037,7 @@ msgid "手动输入 ID"
 msgstr "手动输入 ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:108
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:380
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:409
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
 msgid "打开效果编辑器"
 msgstr "打开效果编辑器"
@@ -1104,7 +1112,7 @@ msgstr "提示：在编辑结束后，如果发现有失效的鉴赏 CG/BGM ，�
 msgid "提示：换行符最多可达三行"
 msgstr "提示：换行符最多可达三行"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:500
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:529
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 
@@ -1123,6 +1131,14 @@ msgstr "搜索选项"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:120
 msgid "播放一小段视频"
 msgstr "播放一小段视频"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:73
+msgid "播放一次后消失"
+msgstr "播放一次后消失"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:72
+msgid "播放一次并停在最后一帧"
+msgstr "播放一次并停在最后一帧"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/index.tsx:184
 msgid "播放一段效果音"
@@ -1157,7 +1173,7 @@ msgid "效果编辑"
 msgstr "效果编辑"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:112
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:385
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:414
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:64
 msgid "效果编辑器"
 msgstr "效果编辑器"
@@ -1357,7 +1373,7 @@ msgid "显示侧边栏"
 msgstr "显示侧边栏"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:105
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:374
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:403
 msgid "显示效果"
 msgstr "显示效果"
 
@@ -1365,7 +1381,7 @@ msgstr "显示效果"
 msgid "显示文本框"
 msgstr "显示文本框"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:258
 msgid "显示立绘"
 msgstr "显示立绘"
 
@@ -1398,14 +1414,14 @@ msgid "本句前插入句子"
 msgstr "本句前插入句子"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:273
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:289
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后执行下一句"
 msgstr "本句执行后执行下一句"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:274
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:290
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后等待"
@@ -1647,7 +1663,7 @@ msgstr "目前没有打开任何文件"
 msgid "相对"
 msgstr "相对"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:464
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:493
 msgid "睁开眼睛"
 msgstr "睁开眼睛"
 
@@ -1696,7 +1712,7 @@ msgstr "禁用"
 msgid "立绘"
 msgstr "立绘"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:387
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:113
@@ -1704,11 +1720,11 @@ msgstr "立绘"
 msgid "立绘 ID"
 msgstr "立绘 ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:378
 msgid "立绘ID（可选）"
 msgstr "立绘ID（可选）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:367
 msgid "立绘位置"
 msgstr "立绘位置"
 
@@ -1716,7 +1732,7 @@ msgstr "立绘位置"
 msgid "立绘插图的ID"
 msgstr "立绘插图的ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:264
 msgid "立绘文件"
 msgstr "立绘文件"
 
@@ -1727,10 +1743,6 @@ msgstr "简体中文"
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:209
 msgid "紧急回避"
 msgstr "紧急回避"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
-msgid "繁体中文"
-msgstr "繁体中文"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1808,7 +1820,7 @@ msgid "缓出"
 msgstr "缓出"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:363
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:392
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:117
 msgid "缓动类型"
 msgstr "缓动类型"
@@ -1828,6 +1840,10 @@ msgstr "编辑游戏"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "编辑组件"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+msgid "繁体中文"
+msgstr "繁体中文"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
@@ -1904,7 +1920,7 @@ msgstr "自动隐藏功能区"
 msgid "自定义"
 msgstr "自定义"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:351
 msgid "自定义 Live2D 绘制范围"
 msgstr "自定义 Live2D 绘制范围"
 
@@ -1925,7 +1941,7 @@ msgstr "自定义特效名称"
 msgid "自定义级联选择器分隔符"
 msgstr "自定义级联选择器分隔符"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:351
 msgid "自定义绘制范围"
 msgstr "自定义绘制范围"
 
@@ -2142,8 +2158,8 @@ msgstr "输入目标 ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:114
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:388
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:391
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:420
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:71
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:74
 msgid "过渡时间（单位为毫秒）"
@@ -2170,7 +2186,7 @@ msgid "进出场动画"
 msgstr "进出场动画"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:266
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:282
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
 msgid "连续执行"
@@ -2232,13 +2248,13 @@ msgstr "选择游戏引擎版本"
 msgid "选择视频文件"
 msgstr "选择视频文件"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:237
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:434
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:451
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:468
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:485
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:253
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:268
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:446
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:463
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:480
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:497
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:514
 msgid "选择立绘文件"
 msgstr "选择立绘文件"
 
@@ -2366,11 +2382,11 @@ msgstr "鉴赏资源文件"
 msgid "鉴赏音乐"
 msgstr "鉴赏音乐"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:447
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:476
 msgid "闭上嘴"
 msgstr "闭上嘴"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:481
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:510
 msgid "闭上眼睛"
 msgstr "闭上眼睛"
 

--- a/packages/origine2/src/locales/zhCn.po
+++ b/packages/origine2/src/locales/zhCn.po
@@ -30,7 +30,7 @@ msgstr "<0>应用新的模板</0>"
 msgid "<0>当前应用的模板：{currentTemplateName}</0>"
 msgstr "<0>当前应用的模板：{currentTemplateName}</0>"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:216
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:288
 msgid "1, 2, 3, ..."
 msgstr "1, 2, 3, ..."
 
@@ -94,11 +94,19 @@ msgstr "Intro 文本"
 msgid "intro:;"
 msgstr "intro:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:222
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+msgid "JSONL 动作"
+msgstr "JSONL 动作"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
+msgid "JSONL 表情"
+msgstr "JSONL 表情"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
 msgid "Live2D 动作"
 msgstr "Live2D 动作"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:233
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:310
 msgid "Live2D 表情"
 msgstr "Live2D 表情"
 
@@ -142,7 +150,7 @@ msgstr "setTransform: -duration=0;"
 msgid "setTransition:;"
 msgstr "setTransition:;"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:222
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
 msgid "Spine 动画"
 msgstr "Spine 动画"
 
@@ -194,7 +202,7 @@ msgstr "Y轴位移"
 msgid "Y轴缩放"
 msgstr "Y轴缩放"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:208
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:279
 msgid "z-index"
 msgstr "z-index"
 
@@ -248,7 +256,7 @@ msgstr "个字"
 msgid "中"
 msgstr "中"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:55
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
 msgid "中间"
 msgstr "中间"
 
@@ -338,7 +346,7 @@ msgstr "使用预设的作用目标，如果设置了id则不生效"
 msgid "使用预设目标"
 msgstr "使用预设目标"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:331
 msgid "例如：-100,-100,100,100"
 msgstr "例如：-100,-100,100,100"
 
@@ -447,8 +455,8 @@ msgstr "关闭小头像"
 msgid "关闭效果音"
 msgstr "关闭效果音"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:181
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:188
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:232
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:241
 msgid "关闭立绘"
 msgstr "关闭立绘"
 
@@ -595,7 +603,7 @@ msgstr "加粗"
 msgid "动画"
 msgstr "动画"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:334
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:430
 msgid "半张嘴"
 msgstr "半张嘴"
 
@@ -643,7 +651,7 @@ msgstr "变换"
 msgid "可选项"
 msgstr "可选项"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:58
 msgid "右侧"
 msgstr "右侧"
 
@@ -679,7 +687,7 @@ msgstr "启用"
 msgid "启用视频跳过"
 msgstr "启用视频跳过"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:311
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:402
 msgid "唇形同步与眨眼"
 msgstr "唇形同步与眨眼"
 
@@ -919,7 +927,7 @@ msgstr "展示小头像"
 msgid "属性"
 msgstr "属性"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:56
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:57
 msgid "左侧"
 msgstr "左侧"
 
@@ -985,7 +993,7 @@ msgstr "延迟时间（秒）"
 msgid "开启"
 msgstr "开启"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:413
 msgid "张开嘴"
 msgstr "张开嘴"
 
@@ -1021,7 +1029,7 @@ msgid "手动输入 ID"
 msgstr "手动输入 ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:108
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:294
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:380
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:62
 msgid "打开效果编辑器"
 msgstr "打开效果编辑器"
@@ -1096,7 +1104,7 @@ msgstr "提示：在编辑结束后，如果发现有失效的鉴赏 CG/BGM ，�
 msgid "提示：换行符最多可达三行"
 msgstr "提示：换行符最多可达三行"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:384
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:500
 msgid "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 msgstr "提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令"
 
@@ -1149,7 +1157,7 @@ msgid "效果编辑"
 msgstr "效果编辑"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:112
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:297
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:385
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:64
 msgid "效果编辑器"
 msgstr "效果编辑器"
@@ -1349,7 +1357,7 @@ msgid "显示侧边栏"
 msgstr "显示侧边栏"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:105
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:291
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:374
 msgid "显示效果"
 msgstr "显示效果"
 
@@ -1357,7 +1365,7 @@ msgstr "显示效果"
 msgid "显示文本框"
 msgstr "显示文本框"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:188
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:242
 msgid "显示立绘"
 msgstr "显示立绘"
 
@@ -1390,14 +1398,14 @@ msgid "本句前插入句子"
 msgstr "本句前插入句子"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:80
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:205
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:273
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后执行下一句"
 msgstr "本句执行后执行下一句"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:81
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:206
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:102
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:143
 msgid "本句执行后等待"
@@ -1639,7 +1647,7 @@ msgstr "目前没有打开任何文件"
 msgid "相对"
 msgstr "相对"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:464
 msgid "睁开眼睛"
 msgstr "睁开眼睛"
 
@@ -1688,7 +1696,7 @@ msgstr "禁用"
 msgid "立绘"
 msgstr "立绘"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:277
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:358
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Say.tsx:274
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:82
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:113
@@ -1696,11 +1704,11 @@ msgstr "立绘"
 msgid "立绘 ID"
 msgstr "立绘 ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:269
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
 msgid "立绘ID（可选）"
 msgstr "立绘ID（可选）"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:259
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:338
 msgid "立绘位置"
 msgstr "立绘位置"
 
@@ -1708,7 +1716,7 @@ msgstr "立绘位置"
 msgid "立绘插图的ID"
 msgstr "立绘插图的ID"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:191
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:248
 msgid "立绘文件"
 msgstr "立绘文件"
 
@@ -1719,6 +1727,10 @@ msgstr "简体中文"
 #: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:209
 msgid "紧急回避"
 msgstr "紧急回避"
+
+#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
+msgid "繁体中文"
+msgstr "繁体中文"
 
 #: src/pages/editor/EditorSidebar/EditorSidebar.tsx:119
 msgid "纹理"
@@ -1796,7 +1808,7 @@ msgid "缓出"
 msgstr "缓出"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:83
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:281
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:363
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:117
 msgid "缓动类型"
 msgstr "缓动类型"
@@ -1816,10 +1828,6 @@ msgstr "编辑游戏"
 #: src/pages/editor/GraphicalEditor/SentenceEditor/Template.tsx:11
 msgid "编辑组件"
 msgstr "编辑组件"
-
-#: src/pages/editor/Topbar/tabs/GameConfig/GameConfig.tsx:236
-msgid "繁体中文"
-msgstr "繁体中文"
 
 #: src/components/Transformer/Transformer.tsx:183
 #: src/components/Transformer/Transformer.tsx:194
@@ -1896,7 +1904,7 @@ msgstr "自动隐藏功能区"
 msgid "自定义"
 msgstr "自定义"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:244
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
 msgid "自定义 Live2D 绘制范围"
 msgstr "自定义 Live2D 绘制范围"
 
@@ -1916,6 +1924,10 @@ msgstr "自定义特效名称"
 #: src/pages/editor/Topbar/tabs/Settings/SettingsTab.tsx:146
 msgid "自定义级联选择器分隔符"
 msgstr "自定义级联选择器分隔符"
+
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:322
+msgid "自定义绘制范围"
+msgstr "自定义绘制范围"
 
 #: src/pages/editor/Topbar/tabs/AddSentence/AddSentenceTab.tsx:45
 msgid "舞台对象控制"
@@ -2130,8 +2142,8 @@ msgstr "输入目标 ID"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:114
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:117
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:300
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:302
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:388
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:391
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:71
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:74
 msgid "过渡时间（单位为毫秒）"
@@ -2158,7 +2170,7 @@ msgid "进出场动画"
 msgstr "进出场动画"
 
 #: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeBg.tsx:76
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:201
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:266
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetAnimation.tsx:98
 #: src/pages/editor/GraphicalEditor/SentenceEditor/SetTransform.tsx:139
 msgid "连续执行"
@@ -2220,13 +2232,13 @@ msgstr "选择游戏引擎版本"
 msgid "选择视频文件"
 msgstr "选择视频文件"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:184
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:194
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:325
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:337
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:349
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:361
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:373
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:237
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:252
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:417
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:434
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:451
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:468
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:485
 msgid "选择立绘文件"
 msgstr "选择立绘文件"
 
@@ -2354,11 +2366,11 @@ msgstr "鉴赏资源文件"
 msgid "鉴赏音乐"
 msgstr "鉴赏音乐"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:346
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:447
 msgid "闭上嘴"
 msgstr "闭上嘴"
 
-#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:370
+#: src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx:481
 msgid "闭上眼睛"
 msgstr "闭上眼睛"
 

--- a/packages/origine2/src/pages/editor/ChooseFile/chooseFileConfig.ts
+++ b/packages/origine2/src/pages/editor/ChooseFile/chooseFileConfig.ts
@@ -2,8 +2,8 @@ export type IExtNameType = 'scene' | 'image' | 'audio' | 'video' | 'tex' | 'json
 export const extNameMap = new Map<IExtNameType, string[]>([]);
 
 extNameMap.set('scene', ['.txt']);
-extNameMap.set('image', ['.png', '.jpg', '.jpeg', '.webp','webm','mov','gif']);
+extNameMap.set('image', ['.png', '.jpg', '.jpeg', '.webp','.webm','.mov','.gif']);
 extNameMap.set('video', ['.mp4', '.webm', '.mkv','mov']);
 extNameMap.set('audio', ['.mp3', '.ogg', '.wav','.flac']);
 extNameMap.set('tex', ['.png', '.webp']);
-extNameMap.set('json', ['.json','jsonl']);
+extNameMap.set('json', ['.json','.jsonl']);

--- a/packages/origine2/src/pages/editor/ChooseFile/chooseFileConfig.ts
+++ b/packages/origine2/src/pages/editor/ChooseFile/chooseFileConfig.ts
@@ -2,8 +2,8 @@ export type IExtNameType = 'scene' | 'image' | 'audio' | 'video' | 'tex' | 'json
 export const extNameMap = new Map<IExtNameType, string[]>([]);
 
 extNameMap.set('scene', ['.txt']);
-extNameMap.set('image', ['.png', '.jpg', '.jpeg', '.webp']);
-extNameMap.set('video', ['.mp4', '.webm', '.mkv']);
-extNameMap.set('audio', ['.mp3', '.ogg', '.wav']);
+extNameMap.set('image', ['.png', '.jpg', '.jpeg', '.webp','webm','mov','gif']);
+extNameMap.set('video', ['.mp4', '.webm', '.mkv','mov']);
+extNameMap.set('audio', ['.mp3', '.ogg', '.wav','.flac']);
 extNameMap.set('tex', ['.png', '.webp']);
-extNameMap.set('json', ['.json']);
+extNameMap.set('json', ['.json','jsonl']);

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
@@ -21,7 +21,9 @@ import { useEaseTypeOptions } from "@/hooks/useEaseTypeOptions";
 
 type FigurePosition = "" | "left" | "right";
 type AnimationFlag = "" | "on";
+type LoopMode = "true" | "false" | "disappear";
 
+// eslint-disable-next-line complexity
 export default function ChangeFigure(props: ISentenceEditorProps) {
   const gameDir = useEditorStore.use.subPage();
   const updateExpand = useEditorStore.use.updateExpand();
@@ -42,6 +44,9 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
   const animationFlag = useValue(getArgByKey(props.sentence, "animationFlag").toString() ?? "");
   const bounds = useValue(getArgByKey(props.sentence, "bounds").toString() ?? "");
   const zIndex = useValue(String(getArgByKey(props.sentence, "zIndex") ?? ""));
+  const loopMode = useValue<LoopMode>(
+    ((getArgByKey(props.sentence, "loop") as string) || "true") as LoopMode
+  );
 
   const [isAccordionOpen, setIsAccordionOpen] = useState(false);
   const [l2dMotionsList, setL2dMotionsList] = useState<string[]>([]);
@@ -62,11 +67,21 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
     ["", "OFF"],
     ["on", "ON"],
   ]);
+  const loopModes = new Map<LoopMode, string>([
+    ["true",     t`循环播放`],
+    ["false",    t`播放一次并停在最后一帧`],
+    ["disappear",t`播放一次后消失`],
+  ]);
 
   const ease = useValue(getArgByKey(props.sentence, "ease").toString() ?? "");
   const easeTypeOptions = useEaseTypeOptions();
 
   const isJsonlPath = (p: string) => p?.toLowerCase()?.endsWith(".jsonl");
+
+  const isVideoLike = (p: string) => {
+    const s = (p || "").toLowerCase();
+    return s.endsWith(".webm") || s.endsWith(".mp4") || s.endsWith(".mov") || s.endsWith(".gif");
+  };
 
   function parseJsonlSummary(text: string): { motions: string[]; expressions: string[] } {
     const lines = text.split("\n").map((s) => s.trim()).filter(Boolean);
@@ -113,16 +128,16 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
       setIsJsonlFormat(true);
       const url = `/games/${gameDir}/game/figure/${pathRaw}`;
       axios
-          .get(url, { responseType: "text" })
-          .then((resp) => {
-            const { motions, expressions } = parseJsonlSummary(resp.data || "");
-            setL2dMotionsList(motions);
-            setL2dExpressionsList(expressions);
-          })
-          .catch(() => {
-            setL2dMotionsList([]);
-            setL2dExpressionsList([]);
-          });
+        .get(url, { responseType: "text" })
+        .then((resp) => {
+          const { motions, expressions } = parseJsonlSummary(resp.data || "");
+          setL2dMotionsList(motions);
+          setL2dExpressionsList(expressions);
+        })
+        .catch(() => {
+          setL2dMotionsList([]);
+          setL2dExpressionsList([]);
+        });
       return;
     }
 
@@ -158,7 +173,7 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
         }
         if (data?.["FileReferences"]?.["Expressions"]) {
           const exps: string[] = (data["FileReferences"]["Expressions"] as Array<{ Name: string }>)?.map(
-              (e) => e.Name
+            (e) => e.Name
           );
           setL2dExpressionsList((exps || []).sort((a, b) => a.localeCompare(b)));
         }
@@ -182,41 +197,42 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
 
   const submit = () => {
     const submitString = combineSubmitString(
-        props.sentence.commandRaw,
-        figureFile.value,
-        props.sentence.args,
-        [
-          { key: "left", value: figurePosition.value === "left" },
-          { key: "right", value: figurePosition.value === "right" },
-          { key: "id", value: id.value },
-          { key: "transform", value: json.value },
-          { key: "duration", value: duration.value },
+      props.sentence.commandRaw,
+      figureFile.value,
+      props.sentence.args,
+      [
+        { key: "left", value: figurePosition.value === "left" },
+        { key: "right", value: figurePosition.value === "right" },
+        { key: "id", value: id.value },
+        { key: "transform", value: json.value },
+        { key: "duration", value: duration.value },
 
-          ...(animationFlag.value !== ""
-              ? [
-                { key: "animationFlag", value: animationFlag.value },
-                { key: "eyesOpen", value: eyesOpen.value },
-                { key: "eyesClose", value: eyesClose.value },
-                { key: "mouthOpen", value: mouthOpen.value },
-                { key: "mouthHalfOpen", value: mouthHalfOpen.value },
-                { key: "mouthClose", value: mouthClose.value },
-              ]
-              : [
-                { key: "animationFlag", value: "" },
-                { key: "eyesOpen", value: "" },
-                { key: "eyesClose", value: "" },
-                { key: "mouthOpen", value: "" },
-                { key: "mouthHalfOpen", value: "" },
-                { key: "mouthClose", value: "" },
-              ]),
+        ...(animationFlag.value !== ""
+          ? [
+            { key: "animationFlag", value: animationFlag.value },
+            { key: "eyesOpen", value: eyesOpen.value },
+            { key: "eyesClose", value: eyesClose.value },
+            { key: "mouthOpen", value: mouthOpen.value },
+            { key: "mouthHalfOpen", value: mouthHalfOpen.value },
+            { key: "mouthClose", value: mouthClose.value },
+          ]
+          : [
+            { key: "animationFlag", value: "" },
+            { key: "eyesOpen", value: "" },
+            { key: "eyesClose", value: "" },
+            { key: "mouthOpen", value: "" },
+            { key: "mouthHalfOpen", value: "" },
+            { key: "mouthClose", value: "" },
+          ]),
 
-          { key: "motion", value: currentMotion.value },
-          { key: "expression", value: currentExpression.value },
-          { key: "bounds", value: bounds.value },
-          { key: "ease", value: ease.value },
-          { key: "zIndex", value: zIndex.value },
-          { key: "next", value: isGoNext.value },
-        ]
+        { key: "motion", value: currentMotion.value },
+        { key: "expression", value: currentExpression.value },
+        { key: "bounds", value: bounds.value },
+        { key: "ease", value: ease.value },
+        { key: "zIndex", value: zIndex.value },
+        { key: "loop", value: loopMode.value },
+        { key: "next", value: isGoNext.value },
+      ]
     );
     props.onSubmit(submitString);
   };
@@ -227,287 +243,300 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
       fileLower.endsWith(".json") || fileLower.endsWith(".jsonl") || fileLower.includes(".json?");
 
   return (
-      <div className={styles.sentenceEditorContent}>
-        <div className={styles.editItem}>
-          <CommonOptions key="isNoDialog" title={t`关闭立绘`}>
-            <TerreToggle
-                title=""
-                onChange={(newValue) => {
-                  if (!newValue) {
-                    figureFile.set(t`选择立绘文件`);
-                  } else figureFile.set("none");
+    <div className={styles.sentenceEditorContent}>
+      <div className={styles.editItem}>
+        <CommonOptions key="isNoDialog" title={t`关闭立绘`}>
+          <TerreToggle
+            title=""
+            onChange={(newValue) => {
+              if (!newValue) {
+                figureFile.set(t`选择立绘文件`);
+              } else figureFile.set("none");
+              submit();
+            }}
+            onText={t`关闭立绘`}
+            offText={t`显示立绘`}
+            isChecked={isNoFile}
+          />
+        </CommonOptions>
+
+        {!isNoFile && (
+          <CommonOptions key="1" title={t`立绘文件`}>
+            <>
+              {figureFile.value + "\u00a0\u00a0"}
+              <ChooseFile
+                title={t`选择立绘文件`}
+                basePath={["figure"]}
+                selectedFilePath={figureFile.value}
+                onChange={(fileDesc) => {
+                  figureFile.set(fileDesc?.name ?? "");
                   submit();
                 }}
-                onText={t`关闭立绘`}
-                offText={t`显示立绘`}
-                isChecked={isNoFile}
+                // 允许 .jsonl
+                extNames={[...(extNameMap.get("image") ?? []), ...(extNameMap.get("json") ?? []), ".jsonl"]}
+              />
+            </>
+          </CommonOptions>
+        )}
+
+        <CommonOptions key="2" title={t`连续执行`}>
+          <TerreToggle
+            title=""
+            onChange={(newValue) => {
+              isGoNext.set(newValue);
+              submit();
+            }}
+            onText={t`本句执行后执行下一句`}
+            offText={t`本句执行后等待`}
+            isChecked={isGoNext.value}
+          />
+        </CommonOptions>
+
+        <CommonOptions title={t`z-index`} key="z-index">
+          <input
+            value={zIndex.value}
+            onChange={(ev) => {
+              const newValue = ev.target.value;
+              zIndex.set(newValue ?? "");
+            }}
+            onBlur={submit}
+            className={styles.sayInput}
+            placeholder={t`1, 2, 3, ...`}
+            style={{ width: "100%" }}
+          />
+        </CommonOptions>
+
+        {!isNoFile && isVideoLike(figureFile.value) && (
+          <CommonOptions title={t`循环模式（仅视频/GIF 立绘）`} key="loop-mode">
+            <WheelDropdown
+              options={loopModes}
+              value={loopMode.value}
+              onValueChange={(newValue) => {
+                loopMode.set((newValue?.toString() as LoopMode) ?? "true");
+                submit();
+              }}
             />
           </CommonOptions>
+        )}
 
-          {!isNoFile && (
-              <CommonOptions key="1" title={t`立绘文件`}>
+        {isModelMetaFile && (
+          <>
+            <CommonOptions
+              key="24"
+              title={isSpineJsonFormat ? t`Spine 动画` : isJsonlFormat ? t`JSONL 动作` : t`Live2D 动作`}
+            >
+              <SearchableCascader
+                optionList={l2dMotionsList}
+                value={currentMotion.value}
+                onValueChange={(newValue) => {
+                  newValue && currentMotion.set(newValue);
+                  submit();
+                }}
+              />
+            </CommonOptions>
+
+            {!isSpineJsonFormat && (
+              <CommonOptions key="25" title={isJsonlFormat ? t`JSONL 表情` : t`Live2D 表情`}>
+                <SearchableCascader
+                  optionList={l2dExpressionsList}
+                  value={currentExpression.value}
+                  onValueChange={(newValue) => {
+                    newValue && currentExpression.set(newValue);
+                    submit();
+                  }}
+                />
+              </CommonOptions>
+            )}
+
+            <CommonOptions title={isJsonlFormat ? t`自定义绘制范围` : t`自定义 Live2D 绘制范围`} key="bounds">
+              <input
+                value={bounds.value}
+                onChange={(ev) => {
+                  const newValue = ev.target.value;
+                  bounds.set(newValue ?? "");
+                }}
+                onBlur={submit}
+                className={styles.sayInput}
+                placeholder={t`例如：-100,-100,100,100`}
+                style={{ width: "100%" }}
+              />
+            </CommonOptions>
+          </>
+        )}
+
+        <CommonOptions title={t`立绘位置`} key="3">
+          <WheelDropdown
+            options={figurePositions}
+            value={figurePosition.value}
+            onValueChange={(newValue) => {
+              figurePosition.set((newValue?.toString() as FigurePosition) ?? "");
+              submit();
+            }}
+          />
+        </CommonOptions>
+
+        <CommonOptions title={t`立绘ID（可选）`} key="4">
+          <input
+            value={id.value}
+            onChange={(ev) => {
+              const newValue = ev.target.value;
+              id.set(newValue ?? "");
+            }}
+            onBlur={submit}
+            className={styles.sayInput}
+            placeholder={t`立绘 ID`}
+            style={{ width: "100%" }}
+          />
+        </CommonOptions>
+
+        <CommonOptions key="5" title={t`缓动类型`}>
+          <WheelDropdown
+            options={easeTypeOptions}
+            value={ease.value}
+            onValueChange={(newValue) => {
+              ease.set(newValue?.toString() ?? "");
+              submit();
+            }}
+          />
+        </CommonOptions>
+
+        <CommonOptions key="23" title={t`显示效果`}>
+          <Button
+            onClick={() => {
+              updateExpand(props.index);
+            }}
+          >
+            {t`打开效果编辑器`}
+          </Button>
+        </CommonOptions>
+
+        <TerrePanel
+          title={t`效果编辑器`}
+          sentenceIndex={props.index}
+          bottomBarChildren={[
+            <CommonOptions key="10" title={t`过渡时间（单位为毫秒）`}>
+              <div>
+                <Input
+                  placeholder={t`过渡时间（单位为毫秒）`}
+                  value={duration.value.toString()}
+                  onChange={(_, data) => {
+                    const newDuration = Number(data.value);
+                    if (isNaN(newDuration) || data.value === "") duration.set("");
+                    else duration.set(newDuration);
+                  }}
+                  onBlur={submit}
+                />
+              </div>
+            </CommonOptions>,
+            <CommonOptions title={t`唇形同步与眨眼`} key="5">
+              <WheelDropdown
+                options={animationFlags}
+                value={animationFlag.value}
+                onValueChange={(newValue) => {
+                  animationFlag.set(newValue?.toString() ?? "");
+                  submit();
+                }}
+              />
+            </CommonOptions>,
+            <div key="mouth-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+              <CommonOptions key="6" title={t`张开嘴`}>
                 <>
-                  {figureFile.value + "\u00a0\u00a0"}
+                  {mouthOpen.value + "\u00a0\u00a0"}
                   <ChooseFile
-                      title={t`选择立绘文件`}
-                      basePath={["figure"]}
-                      selectedFilePath={figureFile.value}
-                      onChange={(fileDesc) => {
-                        figureFile.set(fileDesc?.name ?? "");
-                        submit();
-                      }}
-                      // 允许 .jsonl
-                      extNames={[...(extNameMap.get("image") ?? []), ...(extNameMap.get("json") ?? []), ".jsonl"]}
+                    title={t`选择立绘文件`}
+                    basePath={["figure"]}
+                    selectedFilePath={mouthOpen.value}
+                    onChange={(fileDesc) => {
+                      mouthOpen.set(fileDesc?.name ?? "");
+                      submit();
+                    }}
+                    extNames={extNameMap.get("image")}
                   />
                 </>
               </CommonOptions>
-          )}
-
-          <CommonOptions key="2" title={t`连续执行`}>
-            <TerreToggle
-                title=""
-                onChange={(newValue) => {
-                  isGoNext.set(newValue);
-                  submit();
-                }}
-                onText={t`本句执行后执行下一句`}
-                offText={t`本句执行后等待`}
-                isChecked={isGoNext.value}
-            />
-          </CommonOptions>
-
-          <CommonOptions title={t`z-index`} key="z-index">
-            <input
-                value={zIndex.value}
-                onChange={(ev) => {
-                  const newValue = ev.target.value;
-                  zIndex.set(newValue ?? "");
-                }}
-                onBlur={submit}
-                className={styles.sayInput}
-                placeholder={t`1, 2, 3, ...`}
-                style={{ width: "100%" }}
-            />
-          </CommonOptions>
-
-          {isModelMetaFile && (
-              <>
-                <CommonOptions
-                    key="24"
-                    title={isSpineJsonFormat ? t`Spine 动画` : isJsonlFormat ? t`JSONL 动作` : t`Live2D 动作`}
-                >
-                  <SearchableCascader
-                      optionList={l2dMotionsList}
-                      value={currentMotion.value}
-                      onValueChange={(newValue) => {
-                        newValue && currentMotion.set(newValue);
-                        submit();
-                      }}
+            </div>,
+            <div key="mouth-half-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+              <CommonOptions key="7" title={t`半张嘴`}>
+                <>
+                  {mouthHalfOpen.value + "\u00a0\u00a0"}
+                  <ChooseFile
+                    title={t`选择立绘文件`}
+                    basePath={["figure"]}
+                    selectedFilePath={mouthHalfOpen.value}
+                    onChange={(fileDesc) => {
+                      mouthHalfOpen.set(fileDesc?.name ?? "");
+                      submit();
+                    }}
+                    extNames={extNameMap.get("image")}
                   />
-                </CommonOptions>
-
-                {!isSpineJsonFormat && (
-                    <CommonOptions key="25" title={isJsonlFormat ? t`JSONL 表情` : t`Live2D 表情`}>
-                      <SearchableCascader
-                          optionList={l2dExpressionsList}
-                          value={currentExpression.value}
-                          onValueChange={(newValue) => {
-                            newValue && currentExpression.set(newValue);
-                            submit();
-                          }}
-                      />
-                    </CommonOptions>
-                )}
-
-                <CommonOptions title={isJsonlFormat ? t`自定义绘制范围` : t`自定义 Live2D 绘制范围`} key="bounds">
-                  <input
-                      value={bounds.value}
-                      onChange={(ev) => {
-                        const newValue = ev.target.value;
-                        bounds.set(newValue ?? "");
-                      }}
-                      onBlur={submit}
-                      className={styles.sayInput}
-                      placeholder={t`例如：-100,-100,100,100`}
-                      style={{ width: "100%" }}
+                </>
+              </CommonOptions>
+            </div>,
+            <div key="mouth-close" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+              <CommonOptions key="8" title={t`闭上嘴`}>
+                <>
+                  {mouthClose.value + "\u00a0\u00a0"}
+                  <ChooseFile
+                    title={t`选择立绘文件`}
+                    basePath={["figure"]}
+                    selectedFilePath={mouthClose.value}
+                    onChange={(fileDesc) => {
+                      mouthClose.set(fileDesc?.name ?? "");
+                      submit();
+                    }}
+                    extNames={extNameMap.get("image")}
                   />
-                </CommonOptions>
-              </>
-          )}
-
-          <CommonOptions title={t`立绘位置`} key="3">
-            <WheelDropdown
-                options={figurePositions}
-                value={figurePosition.value}
-                onValueChange={(newValue) => {
-                  figurePosition.set((newValue?.toString() as FigurePosition) ?? "");
-                  submit();
-                }}
-            />
-          </CommonOptions>
-
-          <CommonOptions title={t`立绘ID（可选）`} key="4">
-            <input
-                value={id.value}
-                onChange={(ev) => {
-                  const newValue = ev.target.value;
-                  id.set(newValue ?? "");
-                }}
-                onBlur={submit}
-                className={styles.sayInput}
-                placeholder={t`立绘 ID`}
-                style={{ width: "100%" }}
-            />
-          </CommonOptions>
-
-          <CommonOptions key="5" title={t`缓动类型`}>
-            <WheelDropdown
-                options={easeTypeOptions}
-                value={ease.value}
-                onValueChange={(newValue) => {
-                  ease.set(newValue?.toString() ?? "");
-                  submit();
-                }}
-            />
-          </CommonOptions>
-
-          <CommonOptions key="23" title={t`显示效果`}>
-            <Button
-                onClick={() => {
-                  updateExpand(props.index);
-                }}
-            >
-              {t`打开效果编辑器`}
-            </Button>
-          </CommonOptions>
-
-          <TerrePanel
-              title={t`效果编辑器`}
-              sentenceIndex={props.index}
-              bottomBarChildren={[
-                <CommonOptions key="10" title={t`过渡时间（单位为毫秒）`}>
-                  <div>
-                    <Input
-                        placeholder={t`过渡时间（单位为毫秒）`}
-                        value={duration.value.toString()}
-                        onChange={(_, data) => {
-                          const newDuration = Number(data.value);
-                          if (isNaN(newDuration) || data.value === "") duration.set("");
-                          else duration.set(newDuration);
-                        }}
-                        onBlur={submit}
-                    />
-                  </div>
-                </CommonOptions>,
-                <CommonOptions title={t`唇形同步与眨眼`} key="5">
-                  <WheelDropdown
-                      options={animationFlags}
-                      value={animationFlag.value}
-                      onValueChange={(newValue) => {
-                        animationFlag.set(newValue?.toString() ?? "");
-                        submit();
-                      }}
+                </>
+              </CommonOptions>
+            </div>,
+            <div key="eyes-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+              <CommonOptions key="9" title={t`睁开眼睛`}>
+                <>
+                  {eyesOpen.value + "\u00a0\u00a0"}
+                  <ChooseFile
+                    title={t`选择立绘文件`}
+                    basePath={["figure"]}
+                    selectedFilePath={eyesOpen.value}
+                    onChange={(fileDesc) => {
+                      eyesOpen.set(fileDesc?.name ?? "");
+                      submit();
+                    }}
+                    extNames={extNameMap.get("image")}
                   />
-                </CommonOptions>,
-                <div key="mouth-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
-                  <CommonOptions key="6" title={t`张开嘴`}>
-                    <>
-                      {mouthOpen.value + "\u00a0\u00a0"}
-                      <ChooseFile
-                          title={t`选择立绘文件`}
-                          basePath={["figure"]}
-                          selectedFilePath={mouthOpen.value}
-                          onChange={(fileDesc) => {
-                            mouthOpen.set(fileDesc?.name ?? "");
-                            submit();
-                          }}
-                          extNames={extNameMap.get("image")}
-                      />
-                    </>
-                  </CommonOptions>
-                </div>,
-                <div key="mouth-half-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
-                  <CommonOptions key="7" title={t`半张嘴`}>
-                    <>
-                      {mouthHalfOpen.value + "\u00a0\u00a0"}
-                      <ChooseFile
-                          title={t`选择立绘文件`}
-                          basePath={["figure"]}
-                          selectedFilePath={mouthHalfOpen.value}
-                          onChange={(fileDesc) => {
-                            mouthHalfOpen.set(fileDesc?.name ?? "");
-                            submit();
-                          }}
-                          extNames={extNameMap.get("image")}
-                      />
-                    </>
-                  </CommonOptions>
-                </div>,
-                <div key="mouth-close" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
-                  <CommonOptions key="8" title={t`闭上嘴`}>
-                    <>
-                      {mouthClose.value + "\u00a0\u00a0"}
-                      <ChooseFile
-                          title={t`选择立绘文件`}
-                          basePath={["figure"]}
-                          selectedFilePath={mouthClose.value}
-                          onChange={(fileDesc) => {
-                            mouthClose.set(fileDesc?.name ?? "");
-                            submit();
-                          }}
-                          extNames={extNameMap.get("image")}
-                      />
-                    </>
-                  </CommonOptions>
-                </div>,
-                <div key="eyes-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
-                  <CommonOptions key="9" title={t`睁开眼睛`}>
-                    <>
-                      {eyesOpen.value + "\u00a0\u00a0"}
-                      <ChooseFile
-                          title={t`选择立绘文件`}
-                          basePath={["figure"]}
-                          selectedFilePath={eyesOpen.value}
-                          onChange={(fileDesc) => {
-                            eyesOpen.set(fileDesc?.name ?? "");
-                            submit();
-                          }}
-                          extNames={extNameMap.get("image")}
-                      />
-                    </>
-                  </CommonOptions>
-                </div>,
-                <div key="eyes-close" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
-                  <CommonOptions key="10" title={t`闭上眼睛`}>
-                    <>
-                      {eyesClose.value + "\u00a0\u00a0"}
-                      <ChooseFile
-                          title={t`选择立绘文件`}
-                          basePath={["figure"]}
-                          selectedFilePath={eyesClose.value}
-                          onChange={(fileDesc) => {
-                            eyesClose.set(fileDesc?.name ?? "");
-                            submit();
-                          }}
-                          extNames={extNameMap.get("image")}
-                      />
-                    </>
-                  </CommonOptions>
-                </div>,
-              ]}
-          >
-            <CommonTips
-                text={t`提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令`}
-            />
-            <EffectEditor
-                json={json.value.toString()}
-                onChange={(newJson) => {
-                  json.set(newJson);
-                  submit();
-                }}
-            />
-          </TerrePanel>
-        </div>
+                </>
+              </CommonOptions>
+            </div>,
+            <div key="eyes-close" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+              <CommonOptions key="10" title={t`闭上眼睛`}>
+                <>
+                  {eyesClose.value + "\u00a0\u00a0"}
+                  <ChooseFile
+                    title={t`选择立绘文件`}
+                    basePath={["figure"]}
+                    selectedFilePath={eyesClose.value}
+                    onChange={(fileDesc) => {
+                      eyesClose.set(fileDesc?.name ?? "");
+                      submit();
+                    }}
+                    extNames={extNameMap.get("image")}
+                  />
+                </>
+              </CommonOptions>
+            </div>,
+          ]}
+        >
+          <CommonTips
+            text={t`提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令`}
+          />
+          <EffectEditor
+            json={json.value.toString()}
+            onChange={(newJson) => {
+              json.set(newJson);
+              submit();
+            }}
+          />
+        </TerrePanel>
       </div>
+    </div>
   );
 }

--- a/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
+++ b/packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx
@@ -1,20 +1,20 @@
 import CommonOptions from "../components/CommonOption";
-import {ISentenceEditorProps} from "./index";
+import { ISentenceEditorProps } from "./index";
 import styles from "./sentenceEditor.module.scss";
 import ChooseFile from "../../ChooseFile/ChooseFile";
-import {useValue} from "../../../../hooks/useValue";
-import {getArgByKey} from "../utils/getArgByKey";
+import { useValue } from "@/hooks/useValue";
+import { getArgByKey } from "../utils/getArgByKey";
 import TerreToggle from "../../../../components/terreToggle/TerreToggle";
-import {useEffect, useMemo, useState} from "react";
-import {EffectEditor} from "@/pages/editor/GraphicalEditor/components/EffectEditor";
+import { useEffect, useState } from "react";
+import { EffectEditor } from "@/pages/editor/GraphicalEditor/components/EffectEditor";
 import CommonTips from "@/pages/editor/GraphicalEditor/components/CommonTips";
 import axios from "axios";
-import {TerrePanel} from "@/pages/editor/GraphicalEditor/components/TerrePanel";
-import {Button, Input} from "@fluentui/react-components";
+import { TerrePanel } from "@/pages/editor/GraphicalEditor/components/TerrePanel";
+import { Button, Input } from "@fluentui/react-components";
 import useEditorStore from "@/store/useEditorStore";
-import {t} from "@lingui/macro";
+import { t } from "@lingui/macro";
 import WheelDropdown from "@/pages/editor/GraphicalEditor/components/WheelDropdown";
-import { combineSubmitString, argToString } from "@/utils/combineSubmitString";
+import { combineSubmitString } from "@/utils/combineSubmitString";
 import { extNameMap } from "../../ChooseFile/chooseFileConfig";
 import SearchableCascader from "@/pages/editor/GraphicalEditor/components/SearchableCascader";
 import { useEaseTypeOptions } from "@/hooks/useEaseTypeOptions";
@@ -25,14 +25,15 @@ type AnimationFlag = "" | "on";
 export default function ChangeFigure(props: ISentenceEditorProps) {
   const gameDir = useEditorStore.use.subPage();
   const updateExpand = useEditorStore.use.updateExpand();
+
   const isGoNext = useValue(!!getArgByKey(props.sentence, "next"));
   const figureFile = useValue(props.sentence.content);
-  const isHaveSpineArg = figureFile.value.includes('?type=spine');
   const figurePosition = useValue<FigurePosition>("");
   const isNoFile = props.sentence.content === "";
   const id = useValue(getArgByKey(props.sentence, "id").toString() ?? "");
-  const json = useValue<string>(getArgByKey(props.sentence, 'transform') as string);
-  const duration = useValue<number | string>(getArgByKey(props.sentence, 'duration') as number);
+  const json = useValue<string>(getArgByKey(props.sentence, "transform") as string);
+  const duration = useValue<number | string>(getArgByKey(props.sentence, "duration") as number);
+
   const mouthOpen = useValue(getArgByKey(props.sentence, "mouthOpen").toString() ?? "");
   const mouthHalfOpen = useValue(getArgByKey(props.sentence, "mouthHalfOpen").toString() ?? "");
   const mouthClose = useValue(getArgByKey(props.sentence, "mouthClose").toString() ?? "");
@@ -40,21 +41,21 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
   const eyesClose = useValue(getArgByKey(props.sentence, "eyesClose").toString() ?? "");
   const animationFlag = useValue(getArgByKey(props.sentence, "animationFlag").toString() ?? "");
   const bounds = useValue(getArgByKey(props.sentence, "bounds").toString() ?? "");
-  const zIndex = useValue(String(getArgByKey(props.sentence, 'zIndex') ?? ''));
+  const zIndex = useValue(String(getArgByKey(props.sentence, "zIndex") ?? ""));
+
   const [isAccordionOpen, setIsAccordionOpen] = useState(false);
   const [l2dMotionsList, setL2dMotionsList] = useState<string[]>([]);
   const [l2dExpressionsList, setL2dExpressionsList] = useState<string[]>([]);
   const [isSpineJsonFormat, setIsSpineJsonFormat] = useState(false);
+  const [isJsonlFormat, setIsJsonlFormat] = useState(false);
 
   const currentMotion = useValue(getArgByKey(props.sentence, "motion").toString() ?? "");
-  const currentExpression = useValue(
-    getArgByKey(props.sentence, "expression").toString() ?? ""
-  );
+  const currentExpression = useValue(getArgByKey(props.sentence, "expression").toString() ?? "");
 
   const figurePositions = new Map<FigurePosition, string>([
     ["", t`中间`],
     ["left", t`左侧`],
-    ["right", t`右侧`]
+    ["right", t`右侧`],
   ]);
 
   const animationFlags = new Map<AnimationFlag, string>([
@@ -62,69 +63,111 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
     ["on", "ON"],
   ]);
 
-  const ease = useValue(getArgByKey(props.sentence, 'ease').toString() ?? '');
+  const ease = useValue(getArgByKey(props.sentence, "ease").toString() ?? "");
   const easeTypeOptions = useEaseTypeOptions();
 
+  const isJsonlPath = (p: string) => p?.toLowerCase()?.endsWith(".jsonl");
+
+  function parseJsonlSummary(text: string): { motions: string[]; expressions: string[] } {
+    const lines = text.split("\n").map((s) => s.trim()).filter(Boolean);
+    for (let i = lines.length - 1; i >= 0; i--) {
+      try {
+        const obj = JSON.parse(lines[i]);
+        if (obj && (obj.motions || obj.expressions)) {
+          let motions: string[] = [];
+          if (Array.isArray(obj.motions)) motions = obj.motions.map(String);
+          else if (obj.motions && typeof obj.motions === "object") motions = Object.keys(obj.motions);
+
+          let expressions: string[] = [];
+          if (Array.isArray(obj.expressions)) expressions = obj.expressions.map(String);
+          else if (obj.expressions && typeof obj.expressions === "object") expressions = Object.keys(obj.expressions);
+
+          // 去重 + 排序
+          motions = Array.from(new Set(motions)).sort((a, b) => a.localeCompare(b));
+          expressions = Array.from(new Set(expressions)).sort((a, b) => a.localeCompare(b));
+
+          return { motions, expressions };
+        }
+      } catch {
+        // ignore this line
+      }
+    }
+    return { motions: [], expressions: [] };
+  }
+
+  // 载入 motions / expressions（支持 .jsonl / .json / spine）
   useEffect(() => {
-    if (figureFile.value.includes('json')) {
-      console.log('loading JSON file to get motion and expression');
-      axios.get(`/games/${gameDir}/game/figure/${figureFile.value}`).then(resp => {
+    // reset
+    setIsJsonlFormat(false);
+    setIsSpineJsonFormat(false);
+    setL2dMotionsList([]);
+    setL2dExpressionsList([]);
+
+    const pathRaw = figureFile.value || "";
+    const pathLower = pathRaw.toLowerCase();
+
+    if (!pathRaw || pathRaw === "none") return;
+
+    // JSONL
+    if (isJsonlPath(pathRaw)) {
+      setIsJsonlFormat(true);
+      const url = `/games/${gameDir}/game/figure/${pathRaw}`;
+      axios
+          .get(url, { responseType: "text" })
+          .then((resp) => {
+            const { motions, expressions } = parseJsonlSummary(resp.data || "");
+            setL2dMotionsList(motions);
+            setL2dExpressionsList(expressions);
+          })
+          .catch(() => {
+            setL2dMotionsList([]);
+            setL2dExpressionsList([]);
+          });
+      return;
+    }
+
+    // JSON（Live2D v2/v3 或 Spine JSON）
+    if (pathLower.endsWith(".json") || pathLower.includes(".json?")) {
+      const url = `/games/${gameDir}/game/figure/${pathRaw}`;
+      axios.get(url).then((resp) => {
         const data = resp.data;
 
-        // 检测是否为 Spine JSON 格式
+        // Spine JSON
         if (data?.animations) {
-          // 处理 Spine JSON 格式的 animations
           setIsSpineJsonFormat(true);
-          const animations = Object.keys(data.animations);
+          const animations = Object.keys(data.animations || {});
           setL2dMotionsList(animations.sort((a, b) => a.localeCompare(b)));
-          // Spine JSON 格式忽略 expressions
-          setL2dExpressionsList([]);
-        } else {
-          // Live2D 格式
-          setIsSpineJsonFormat(false);
-
-          if (data?.motions) {
-            // 处理 motions
-            const motions = Object.keys(data.motions);
-            setL2dMotionsList(motions.sort((a, b) => a.localeCompare(b)));
-          }
-
-          // 处理 expressions
-          if (data?.expressions) {
-            const expressions: string[] = data.expressions.map((exp: { name: string }) => exp.name);
-            setL2dExpressionsList(expressions.sort((a, b) => a.localeCompare(b)));
-          }
-
-          // 处理 v3 版本的 model
-          if (data?.['FileReferences']?.['Motions']) {
-            const motions = Object.keys(data['FileReferences']['Motions']);
-            setL2dMotionsList(motions.sort((a, b) => a.localeCompare(b)));
-          }
-
-          if (data?.['FileReferences']?.['Expressions']) {
-            const expressions: string[] = data['FileReferences']['Expressions'].map((exp: { Name: string }) => exp.Name);
-            setL2dExpressionsList(expressions.sort((a, b) => a.localeCompare(b)));
-          }
+          setL2dExpressionsList([]); // Spine 没有表情
+          return;
         }
 
+        // Live2D v2
+        if (data?.motions) {
+          const motions = Object.keys(data.motions);
+          setL2dMotionsList(motions.sort((a, b) => a.localeCompare(b)));
+        }
+        if (data?.expressions) {
+          const exps: string[] = (data.expressions as Array<{ name: string }>)?.map((e) => e.name);
+          setL2dExpressionsList((exps || []).sort((a, b) => a.localeCompare(b)));
+        }
+
+        // Live2D v3
+        if (data?.["FileReferences"]?.["Motions"]) {
+          const motions = Object.keys(data["FileReferences"]["Motions"]);
+          setL2dMotionsList(motions.sort((a, b) => a.localeCompare(b)));
+        }
+        if (data?.["FileReferences"]?.["Expressions"]) {
+          const exps: string[] = (data["FileReferences"]["Expressions"] as Array<{ Name: string }>)?.map(
+              (e) => e.Name
+          );
+          setL2dExpressionsList((exps || []).sort((a, b) => a.localeCompare(b)));
+        }
       });
-    } else {
-      setIsSpineJsonFormat(false);
     }
-  }, [figureFile.value]);
-  const toggleAccordion = () => {
-    setIsAccordionOpen(!isAccordionOpen);
-  };
-  const optionButtonStyles = {
-    root: {
-      margin: '6px 0 0 0',
-      display: 'flex'
-    },
-  };
+  }, [figureFile.value, gameDir]);
+
   useEffect(() => {
-    /**
-     * 初始化立绘位置
-     */
+    // 初始化立绘位置
     if (getArgByKey(props.sentence, "left")) {
       figurePosition.set("left");
     }
@@ -132,262 +175,339 @@ export default function ChangeFigure(props: ISentenceEditorProps) {
       figurePosition.set("right");
     }
   }, []);
+
   useEffect(() => {
-    if (animationFlag.value === "on") {
-      setIsAccordionOpen(true);
-    } else {
-      setIsAccordionOpen(false);
-    }
+    setIsAccordionOpen(animationFlag.value === "on");
   }, [animationFlag.value]);
+
   const submit = () => {
     const submitString = combineSubmitString(
-      props.sentence.commandRaw,
-      figureFile.value,
-      props.sentence.args,
-      [
-        {key: "left", value: figurePosition.value === "left"},
-        {key: "right", value: figurePosition.value === "right"},
-        {key: "id", value: id.value},
-        {key: "transform", value: json.value},
-        {key: "duration", value: duration.value},
-        ...(animationFlag.value !== "" ? [
-          {key: "animationFlag", value: animationFlag.value},
-          {key: "eyesOpen", value: eyesOpen.value},
-          {key: "eyesClose", value: eyesClose.value},
-          {key: "mouthOpen", value: mouthOpen.value},
-          {key: "mouthHalfOpen", value: mouthHalfOpen.value},
-          {key: "mouthClose", value: mouthClose.value},
-        ] : [
-          {key: "animationFlag", value: ""},
-          {key: "eyesOpen", value: ""},
-          {key: "eyesClose", value: ""},
-          {key: "mouthOpen", value: ""},
-          {key: "mouthHalfOpen", value: ""},
-          {key: "mouthClose", value: ""},
-        ]),
-        {key: "motion", value: currentMotion.value},
-        {key: "expression", value: currentExpression.value},
-        {key: "bounds", value: bounds.value},
-        {key: "ease", value: ease.value},
-        {key: "zIndex", value: zIndex.value},
-        {key: "next", value: isGoNext.value},
-      ],
+        props.sentence.commandRaw,
+        figureFile.value,
+        props.sentence.args,
+        [
+          { key: "left", value: figurePosition.value === "left" },
+          { key: "right", value: figurePosition.value === "right" },
+          { key: "id", value: id.value },
+          { key: "transform", value: json.value },
+          { key: "duration", value: duration.value },
+
+          ...(animationFlag.value !== ""
+              ? [
+                { key: "animationFlag", value: animationFlag.value },
+                { key: "eyesOpen", value: eyesOpen.value },
+                { key: "eyesClose", value: eyesClose.value },
+                { key: "mouthOpen", value: mouthOpen.value },
+                { key: "mouthHalfOpen", value: mouthHalfOpen.value },
+                { key: "mouthClose", value: mouthClose.value },
+              ]
+              : [
+                { key: "animationFlag", value: "" },
+                { key: "eyesOpen", value: "" },
+                { key: "eyesClose", value: "" },
+                { key: "mouthOpen", value: "" },
+                { key: "mouthHalfOpen", value: "" },
+                { key: "mouthClose", value: "" },
+              ]),
+
+          { key: "motion", value: currentMotion.value },
+          { key: "expression", value: currentExpression.value },
+          { key: "bounds", value: bounds.value },
+          { key: "ease", value: ease.value },
+          { key: "zIndex", value: zIndex.value },
+          { key: "next", value: isGoNext.value },
+        ]
     );
     props.onSubmit(submitString);
   };
 
-  return <div className={styles.sentenceEditorContent}>
-    <div className={styles.editItem}>
-      <CommonOptions key="isNoDialog" title={t`关闭立绘`}>
-        <TerreToggle title="" onChange={(newValue) => {
-          if (!newValue) {
-            figureFile.set(t`选择立绘文件`);
-          } else
-            figureFile.set("none");
-          submit();
-        }} onText={t`关闭立绘`} offText={t`显示立绘`} isChecked={isNoFile}/>
-      </CommonOptions>
-      {!isNoFile &&
-        <CommonOptions key="1" title={t`立绘文件`}>
-          <>
-            {figureFile.value + "\u00a0\u00a0"}
-            <ChooseFile title={t`选择立绘文件`} basePath={['figure']} selectedFilePath={figureFile.value} onChange={(fileDesc) => {
-              figureFile.set(fileDesc?.name ?? "");
-              submit();
-            }}
-            extNames={[...extNameMap.get('image') ?? [], ...extNameMap.get('json') ?? [] ]}/>
-          </>
-        </CommonOptions>}
-      <CommonOptions key="2" title={t`连续执行`}>
-        <TerreToggle title="" onChange={(newValue) => {
-          isGoNext.set(newValue);
-          submit();
-        }} onText={t`本句执行后执行下一句`}
-        offText={t`本句执行后等待`} isChecked={isGoNext.value}/>
-      </CommonOptions>
-      <CommonOptions title={t`z-index`} key="z-index">
-        <input value={zIndex.value}
-          onChange={(ev) => {
-            const newValue = ev.target.value;
-            zIndex.set(newValue ?? "");
-          }}
-          onBlur={submit}
-          className={styles.sayInput}
-          placeholder={t`1, 2, 3, ...`}
-          style={{width: "100%"}}
-        />
-      </CommonOptions>
-      {figureFile.value.includes('.json') && (
-        <>
-          <CommonOptions key="24" title={isSpineJsonFormat ? t`Spine 动画` : t`Live2D 动作`}>
-            <SearchableCascader
-              optionList={l2dMotionsList}
-              value={currentMotion.value}
-              onValueChange={(newValue) =>{
-                newValue && currentMotion.set(newValue);
-                submit();
-              }}
-            />
-          </CommonOptions>
-          {!isSpineJsonFormat && (
-            <CommonOptions key="25" title={t`Live2D 表情`}>
-              <SearchableCascader
-                optionList={l2dExpressionsList}
-                value={currentExpression.value}
-                onValueChange={(newValue) =>{
-                  newValue && currentExpression.set(newValue);
+  // 是否展示动作/表情区域：json / jsonl / spine
+  const fileLower = (figureFile.value || "").toLowerCase();
+  const isModelMetaFile =
+      fileLower.endsWith(".json") || fileLower.endsWith(".jsonl") || fileLower.includes(".json?");
+
+  return (
+      <div className={styles.sentenceEditorContent}>
+        <div className={styles.editItem}>
+          <CommonOptions key="isNoDialog" title={t`关闭立绘`}>
+            <TerreToggle
+                title=""
+                onChange={(newValue) => {
+                  if (!newValue) {
+                    figureFile.set(t`选择立绘文件`);
+                  } else figureFile.set("none");
                   submit();
                 }}
-              />
-            </CommonOptions>
+                onText={t`关闭立绘`}
+                offText={t`显示立绘`}
+                isChecked={isNoFile}
+            />
+          </CommonOptions>
+
+          {!isNoFile && (
+              <CommonOptions key="1" title={t`立绘文件`}>
+                <>
+                  {figureFile.value + "\u00a0\u00a0"}
+                  <ChooseFile
+                      title={t`选择立绘文件`}
+                      basePath={["figure"]}
+                      selectedFilePath={figureFile.value}
+                      onChange={(fileDesc) => {
+                        figureFile.set(fileDesc?.name ?? "");
+                        submit();
+                      }}
+                      // 允许 .jsonl
+                      extNames={[...(extNameMap.get("image") ?? []), ...(extNameMap.get("json") ?? []), ".jsonl"]}
+                  />
+                </>
+              </CommonOptions>
           )}
-          <CommonOptions title={t`自定义 Live2D 绘制范围`} key="bounds">
-            <input value={bounds.value}
-              onChange={(ev) => {
-                const newValue = ev.target.value;
-                bounds.set(newValue ?? "");
-              }}
-              onBlur={submit}
-              className={styles.sayInput}
-              placeholder={t`例如：-100,-100,100,100`}
-              style={{width: "100%"}}
+
+          <CommonOptions key="2" title={t`连续执行`}>
+            <TerreToggle
+                title=""
+                onChange={(newValue) => {
+                  isGoNext.set(newValue);
+                  submit();
+                }}
+                onText={t`本句执行后执行下一句`}
+                offText={t`本句执行后等待`}
+                isChecked={isGoNext.value}
             />
           </CommonOptions>
-        </>
-      )}
 
-      <CommonOptions title={t`立绘位置`} key="3">
-        <WheelDropdown
-          options={figurePositions}
-          value={figurePosition.value}
-          onValueChange={(newValue) => {
-            figurePosition.set(newValue?.toString() as FigurePosition ?? "");
-            submit();
-          }}
-        />
-      </CommonOptions>
-      <CommonOptions title={t`立绘ID（可选）`} key="4">
-        <input value={id.value}
-          onChange={(ev) => {
-            const newValue = ev.target.value;
-            id.set(newValue ?? "");
-          }}
-          onBlur={submit}
-          className={styles.sayInput}
-          placeholder={t`立绘 ID`}
-          style={{width: "100%"}}
-        />
-      </CommonOptions>
-      <CommonOptions key="5" title={t`缓动类型`}>
-        <WheelDropdown
-          options={easeTypeOptions}
-          value={ease.value}
-          onValueChange={(newValue) => {
-            ease.set(newValue?.toString() ?? "");
-            submit();
-          }}
-        />
-      </CommonOptions>
-      <CommonOptions key="23" title={t`显示效果`}>
-        <Button onClick={() => {
-          updateExpand(props.index);
-        }}>{t`打开效果编辑器`}</Button>
-      </CommonOptions>
-      <TerrePanel
-        title={t`效果编辑器`}
-        sentenceIndex={props.index}
-        bottomBarChildren={[
-          <CommonOptions key="10" title={t`过渡时间（单位为毫秒）`}>
-            <div>
-              <Input placeholder={t`过渡时间（单位为毫秒）`} value={duration.value.toString()} onChange={(_, data) => {
-                const newDuration = Number(data.value);
-                if (isNaN(newDuration) || data.value === '')
-                  duration.set("");
-                else
-                  duration.set(newDuration);
-              }} onBlur={submit}/>
-            </div>
-          </CommonOptions>,
-          <CommonOptions title={t`唇形同步与眨眼`} key="5">
-            <WheelDropdown
-              options={animationFlags}
-              value={animationFlag.value}
-              onValueChange={(newValue) => {
-                animationFlag.set(newValue?.toString() ?? "");
-                submit();
-              }}
+          <CommonOptions title={t`z-index`} key="z-index">
+            <input
+                value={zIndex.value}
+                onChange={(ev) => {
+                  const newValue = ev.target.value;
+                  zIndex.set(newValue ?? "");
+                }}
+                onBlur={submit}
+                className={styles.sayInput}
+                placeholder={t`1, 2, 3, ...`}
+                style={{ width: "100%" }}
             />
-          </CommonOptions>,
-          <div key="mouth-open" style={{display: animationFlag.value === "on" ? 'flex' : 'none'}}>
-            <CommonOptions key="6" title={t`张开嘴`}>
-              <>
-                {mouthOpen.value + "\u00a0\u00a0"}
-                <ChooseFile title={t`选择立绘文件`} basePath={['figure']} selectedFilePath={mouthOpen.value} onChange={(fileDesc) => {
-                  mouthOpen.set(fileDesc?.name ?? "");
-                  submit();
-                }}
-                extNames={extNameMap.get('image')}/>
-              </>
-            </CommonOptions>
-          </div>,
-          <div key="mouth-half-open" style={{display: animationFlag.value === "on" ? 'flex' : 'none'}}>
-            <CommonOptions key="7" title={t`半张嘴`}>
-              <>
-                {mouthHalfOpen.value + "\u00a0\u00a0"}
-                <ChooseFile title={t`选择立绘文件`} basePath={['figure']} selectedFilePath={mouthHalfOpen.value} onChange={(fileDesc) => {
-                  mouthHalfOpen.set(fileDesc?.name ?? "");
-                  submit();
-                }}
-                extNames={extNameMap.get('image')}/>
-              </>
-            </CommonOptions>
-          </div>,
-          <div key="mouth-close" style={{display: animationFlag.value === "on" ? 'flex' : 'none'}}>
-            <CommonOptions key="8" title={t`闭上嘴`}>
-              <>
-                {mouthClose.value + "\u00a0\u00a0"}
-                <ChooseFile title={t`选择立绘文件`} basePath={['figure']} selectedFilePath={mouthClose.value} onChange={(fileDesc) => {
-                  mouthClose.set(fileDesc?.name ?? "");
-                  submit();
-                }}
-                extNames={extNameMap.get('image')}/>
-              </>
-            </CommonOptions>
-          </div>,
-          <div key="eyes-open" style={{display: animationFlag.value === "on" ? 'flex' : 'none'}}>
-            <CommonOptions key="9" title={t`睁开眼睛`}>
-              <>
-                {eyesOpen.value + "\u00a0\u00a0"}
-                <ChooseFile title={t`选择立绘文件`} basePath={['figure']} selectedFilePath={eyesOpen.value} onChange={(fileDesc) => {
-                  eyesOpen.set(fileDesc?.name ?? "");
-                  submit();
-                }}
-                extNames={extNameMap.get('image')}/>
-              </>
-            </CommonOptions>
-          </div>,
-          <div key="eyes-close" style={{display: animationFlag.value === "on" ? 'flex' : 'none'}}>
-            <CommonOptions key="10" title={t`闭上眼睛`}>
-              <>
-                {eyesClose.value + "\u00a0\u00a0"}
-                <ChooseFile title={t`选择立绘文件`} basePath={['figure']} selectedFilePath={eyesClose.value} onChange={(fileDesc) => {
-                  eyesClose.set(fileDesc?.name ?? "");
-                  submit();
-                }}
-                extNames={extNameMap.get('image')}/>
-              </>
-            </CommonOptions>
-          </div>,
-        ]}
-      >
-        <CommonTips
-          text={t`提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令`}/>
-        <EffectEditor json={json.value.toString()} onChange={(newJson) => {
-          json.set(newJson);
-          submit();
-        }}/>
-      </TerrePanel>
+          </CommonOptions>
 
-    </div>
-  </div>;
+          {isModelMetaFile && (
+              <>
+                <CommonOptions
+                    key="24"
+                    title={isSpineJsonFormat ? t`Spine 动画` : isJsonlFormat ? t`JSONL 动作` : t`Live2D 动作`}
+                >
+                  <SearchableCascader
+                      optionList={l2dMotionsList}
+                      value={currentMotion.value}
+                      onValueChange={(newValue) => {
+                        newValue && currentMotion.set(newValue);
+                        submit();
+                      }}
+                  />
+                </CommonOptions>
+
+                {!isSpineJsonFormat && (
+                    <CommonOptions key="25" title={isJsonlFormat ? t`JSONL 表情` : t`Live2D 表情`}>
+                      <SearchableCascader
+                          optionList={l2dExpressionsList}
+                          value={currentExpression.value}
+                          onValueChange={(newValue) => {
+                            newValue && currentExpression.set(newValue);
+                            submit();
+                          }}
+                      />
+                    </CommonOptions>
+                )}
+
+                <CommonOptions title={isJsonlFormat ? t`自定义绘制范围` : t`自定义 Live2D 绘制范围`} key="bounds">
+                  <input
+                      value={bounds.value}
+                      onChange={(ev) => {
+                        const newValue = ev.target.value;
+                        bounds.set(newValue ?? "");
+                      }}
+                      onBlur={submit}
+                      className={styles.sayInput}
+                      placeholder={t`例如：-100,-100,100,100`}
+                      style={{ width: "100%" }}
+                  />
+                </CommonOptions>
+              </>
+          )}
+
+          <CommonOptions title={t`立绘位置`} key="3">
+            <WheelDropdown
+                options={figurePositions}
+                value={figurePosition.value}
+                onValueChange={(newValue) => {
+                  figurePosition.set((newValue?.toString() as FigurePosition) ?? "");
+                  submit();
+                }}
+            />
+          </CommonOptions>
+
+          <CommonOptions title={t`立绘ID（可选）`} key="4">
+            <input
+                value={id.value}
+                onChange={(ev) => {
+                  const newValue = ev.target.value;
+                  id.set(newValue ?? "");
+                }}
+                onBlur={submit}
+                className={styles.sayInput}
+                placeholder={t`立绘 ID`}
+                style={{ width: "100%" }}
+            />
+          </CommonOptions>
+
+          <CommonOptions key="5" title={t`缓动类型`}>
+            <WheelDropdown
+                options={easeTypeOptions}
+                value={ease.value}
+                onValueChange={(newValue) => {
+                  ease.set(newValue?.toString() ?? "");
+                  submit();
+                }}
+            />
+          </CommonOptions>
+
+          <CommonOptions key="23" title={t`显示效果`}>
+            <Button
+                onClick={() => {
+                  updateExpand(props.index);
+                }}
+            >
+              {t`打开效果编辑器`}
+            </Button>
+          </CommonOptions>
+
+          <TerrePanel
+              title={t`效果编辑器`}
+              sentenceIndex={props.index}
+              bottomBarChildren={[
+                <CommonOptions key="10" title={t`过渡时间（单位为毫秒）`}>
+                  <div>
+                    <Input
+                        placeholder={t`过渡时间（单位为毫秒）`}
+                        value={duration.value.toString()}
+                        onChange={(_, data) => {
+                          const newDuration = Number(data.value);
+                          if (isNaN(newDuration) || data.value === "") duration.set("");
+                          else duration.set(newDuration);
+                        }}
+                        onBlur={submit}
+                    />
+                  </div>
+                </CommonOptions>,
+                <CommonOptions title={t`唇形同步与眨眼`} key="5">
+                  <WheelDropdown
+                      options={animationFlags}
+                      value={animationFlag.value}
+                      onValueChange={(newValue) => {
+                        animationFlag.set(newValue?.toString() ?? "");
+                        submit();
+                      }}
+                  />
+                </CommonOptions>,
+                <div key="mouth-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+                  <CommonOptions key="6" title={t`张开嘴`}>
+                    <>
+                      {mouthOpen.value + "\u00a0\u00a0"}
+                      <ChooseFile
+                          title={t`选择立绘文件`}
+                          basePath={["figure"]}
+                          selectedFilePath={mouthOpen.value}
+                          onChange={(fileDesc) => {
+                            mouthOpen.set(fileDesc?.name ?? "");
+                            submit();
+                          }}
+                          extNames={extNameMap.get("image")}
+                      />
+                    </>
+                  </CommonOptions>
+                </div>,
+                <div key="mouth-half-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+                  <CommonOptions key="7" title={t`半张嘴`}>
+                    <>
+                      {mouthHalfOpen.value + "\u00a0\u00a0"}
+                      <ChooseFile
+                          title={t`选择立绘文件`}
+                          basePath={["figure"]}
+                          selectedFilePath={mouthHalfOpen.value}
+                          onChange={(fileDesc) => {
+                            mouthHalfOpen.set(fileDesc?.name ?? "");
+                            submit();
+                          }}
+                          extNames={extNameMap.get("image")}
+                      />
+                    </>
+                  </CommonOptions>
+                </div>,
+                <div key="mouth-close" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+                  <CommonOptions key="8" title={t`闭上嘴`}>
+                    <>
+                      {mouthClose.value + "\u00a0\u00a0"}
+                      <ChooseFile
+                          title={t`选择立绘文件`}
+                          basePath={["figure"]}
+                          selectedFilePath={mouthClose.value}
+                          onChange={(fileDesc) => {
+                            mouthClose.set(fileDesc?.name ?? "");
+                            submit();
+                          }}
+                          extNames={extNameMap.get("image")}
+                      />
+                    </>
+                  </CommonOptions>
+                </div>,
+                <div key="eyes-open" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+                  <CommonOptions key="9" title={t`睁开眼睛`}>
+                    <>
+                      {eyesOpen.value + "\u00a0\u00a0"}
+                      <ChooseFile
+                          title={t`选择立绘文件`}
+                          basePath={["figure"]}
+                          selectedFilePath={eyesOpen.value}
+                          onChange={(fileDesc) => {
+                            eyesOpen.set(fileDesc?.name ?? "");
+                            submit();
+                          }}
+                          extNames={extNameMap.get("image")}
+                      />
+                    </>
+                  </CommonOptions>
+                </div>,
+                <div key="eyes-close" style={{ display: animationFlag.value === "on" ? "flex" : "none" }}>
+                  <CommonOptions key="10" title={t`闭上眼睛`}>
+                    <>
+                      {eyesClose.value + "\u00a0\u00a0"}
+                      <ChooseFile
+                          title={t`选择立绘文件`}
+                          basePath={["figure"]}
+                          selectedFilePath={eyesClose.value}
+                          onChange={(fileDesc) => {
+                            eyesClose.set(fileDesc?.name ?? "");
+                            submit();
+                          }}
+                          extNames={extNameMap.get("image")}
+                      />
+                    </>
+                  </CommonOptions>
+                </div>,
+              ]}
+          >
+            <CommonTips
+                text={t`提示：效果只有在切换到不同立绘或关闭之前的立绘再重新添加时生效。如果你要为现有的立绘设置效果，请使用单独的设置效果命令`}
+            />
+            <EffectEditor
+                json={json.value.toString()}
+                onChange={(newJson) => {
+                  json.set(newJson);
+                  submit();
+                }}
+            />
+          </TerrePanel>
+        </div>
+      </div>
+  );
 }


### PR DESCRIPTION
## 主要功能
- 可以正确在changeFigure下选用jsonl聚合模型并正确选用动作表情。
- 当changeFigure选择webm,mov,gif,等视频立绘后，可以使用-loop=true/false/disappear进行控制。

## 主要改动
- 在`packages/origine2/src/pages/editor/ChooseFile/chooseFileConfig.ts`添加对.jsonl等格式的支持
- 在`packages/origine2/src/pages/editor/GraphicalEditor/SentenceEditor/ChangeFigure.tsx``中添加`LoopMode `组件，判断是否是`.gif``.webm`等立绘文件，实现对loop参数的管理。